### PR TITLE
2022-03-10 :: 모달 props 추가 및 mouseEnter 이벤트 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "dev": "next dev & jest --watch",
+    "dev": "next dev",
+    "dev:watch": "next dev & jest --watch",
     "build": "rm -rf dist && mkdir dist && tsc",
     "start": "next start",
     "lint": "next lint",

--- a/pages/test/modal/index.tsx
+++ b/pages/test/modal/index.tsx
@@ -17,19 +17,29 @@ export default function ModalTestPage() {
   return (
     <>
       <button onClick={() => setModal(true)}>모달 실행하기</button>
-      <_Modal show={modal} onCloseModal={closeModal} closeButtonSize="20">
+      <_Modal
+        show={modal}
+        onCloseModal={closeModal}
+        closeButtonSize="20px"
+        mobileDefaultStyles={{ width: "90%", height: "60%" }}
+        // showBGAnimation
+        // showModalOpenAnimation
+        closeMent="Close"
+        // hideCloseButton
+        // offAutoClose
+      >
         {new Array(100).fill(1).map((el) => (
           <p>{1}</p>
         ))}
       </_Modal>
       <hr />
 
-      <div style={{ height: "3000px" }}></div>
+      <div style={{ height: "3000px", backgroundColor: "#666666" }}></div>
       <button onClick={() => setModal2(true)}>모달 실행하기2</button>
       <_Modal
         show={modal2}
         onCloseModal={closeModal2}
-        showBGAnimation
+        // showBGAnimation
         // showModalOpenAnimation
         // hideCloseButton
         // closeButtonSize="100"

--- a/src/commons/units/button/index.tsx
+++ b/src/commons/units/button/index.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+import CommonsHooksComponents from "../../hooks";
+
+interface StyleTypes {
+  children: React.ReactNode;
+  className?: string; // 클래스 이름
+  onClickEvent: () => void; // 실행할 클릭 이벤트
+}
+
+export default function _Button({
+  children,
+  className,
+  onClickEvent,
+}: StyleTypes) {
+  const { getAllComponentsClassName } = CommonsHooksComponents();
+
+  return (
+    <button
+      className={getAllComponentsClassName("cmm-button", className)}
+      onClick={onClickEvent}
+      role="button_click_event"
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/commons/units/text/p/index.tsx
+++ b/src/commons/units/text/p/index.tsx
@@ -1,0 +1,24 @@
+import { CSSProperties } from "react";
+import CommonsHooksComponents from "../../../hooks";
+import styled from "@emotion/styled";
+
+interface IProps {
+  text: string;
+  styles?: CSSProperties;
+  className?: string;
+}
+
+// p 태그를 출력하는 컴포넌트
+export default function _PText({ text, styles, className }: IProps) {
+  const { getAllComponentsClassName } = CommonsHooksComponents();
+
+  return (
+    <P style={styles} className={getAllComponentsClassName("_p_", className)}>
+      {text}
+    </P>
+  );
+}
+
+const P = styled.p`
+  margin: 0px;
+`;

--- a/src/commons/units/text/span/index.tsx
+++ b/src/commons/units/text/span/index.tsx
@@ -1,0 +1,22 @@
+import { CSSProperties } from "react";
+import CommonsHooksComponents from "../../../hooks";
+
+interface IProps {
+  text: string;
+  styles?: CSSProperties;
+  className?: string;
+}
+
+// span 태그를 출력하는 컴포넌트
+export default function _SpanText({ text, styles, className }: IProps) {
+  const { getAllComponentsClassName } = CommonsHooksComponents();
+
+  return (
+    <span
+      style={styles}
+      className={getAllComponentsClassName("_spanText_", className)}
+    >
+      {text}
+    </span>
+  );
+}

--- a/src/components/modules/modal/modal.container.tsx
+++ b/src/components/modules/modal/modal.container.tsx
@@ -1,4 +1,10 @@
-import { MutableRefObject, useEffect, useRef, useState } from "react";
+import {
+  MouseEvent,
+  MutableRefObject,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import _ModalUIPage from "./modal.presenter";
 
 import { ModalPropsType, ModalPropsUITypes } from "./modal.types";
@@ -30,6 +36,7 @@ export default function _Modal(props: ModalPropsType) {
     if (!offAutoClose) {
       // 외부 클릭시 실행되는 이벤트
       document.addEventListener("mousedown", handleClickEvent, true);
+
       return () => {
         document.removeEventListener("mousedown", handleClickEvent, true);
       };
@@ -43,10 +50,16 @@ export default function _Modal(props: ModalPropsType) {
     }
   };
 
+  // 마우스 올릴 경우 모달창을 우선 선택 : 스크롤 이벤트 우선 적용
+  const focusContents = () => {
+    _ref.current.click();
+  };
+
   const _props: ModalPropsType & ModalPropsUITypes = { ...props };
   _props.show = isOpen;
   _props._ref = _ref;
   _props._contentsRef = _contentsRef;
+  _props.focusContents = focusContents;
 
   return <_ModalUIPage props={{ ..._props }} />;
 }

--- a/src/components/modules/modal/modal.presenter.tsx
+++ b/src/components/modules/modal/modal.presenter.tsx
@@ -1,5 +1,3 @@
-// import imageList from "../../../commons/images";
-
 import {
   Wrapper,
   Items,
@@ -8,8 +6,9 @@ import {
   CloseButtonWrapper,
   CloseButton,
 } from "./modal.styles";
-// import Image from "../../../commons/units/image";
+
 import { ModalPropsType, ModalPropsUITypes } from "./modal.types";
+import _SpanText from "../../../commons/units/text/span";
 
 const _ModalUIPage = (props: {
   [props: string]: ModalPropsType & ModalPropsUITypes;
@@ -19,12 +18,15 @@ const _ModalUIPage = (props: {
     showBGAnimation,
     _ref,
     styles,
+    mobileDefaultStyles,
     children,
     _contentsRef,
     showModalOpenAnimation,
     hideCloseButton,
     onCloseModal,
     closeButtonSize,
+    closeMent,
+    focusContents,
   } = props.props;
 
   const closeBtnWrapper: { [key: string]: string } = {};
@@ -44,21 +46,33 @@ const _ModalUIPage = (props: {
       showBGAnimation={showBGAnimation || false}
       showModalOpenAnimation={showModalOpenAnimation || false}
     >
-      <Items className="cmm-modal-items">
+      <Items
+        className="cmm-modal-items"
+        mobileDefaultStyles={mobileDefaultStyles || {}}
+        onMouseEnter={focusContents}
+      >
         <CloseButtonWrapper
-          className="cmm-modal-close-wrapper"
+          className="cmm-modal-close-button-wrapper"
           style={closeBtnWrapper}
+          hideCloseButton={hideCloseButton}
+          onClick={onCloseModal}
+          isOpen={show}
+          onAnimation={showModalOpenAnimation}
         >
-          {!hideCloseButton && (
-            <CloseButton
-              className="cmm-modal-close-button"
-              onClick={onCloseModal}
-              style={closeModalStyles}
-            ></CloseButton>
+          {closeMent && (
+            <_SpanText text={closeMent} className="cmm-modal-close-ment" />
           )}
+          <CloseButton
+            className="cmm-modal-close-button"
+            style={closeModalStyles}
+          />
         </CloseButtonWrapper>
-        <Layout className="cmm-modal-layout" ref={_ref} style={styles}>
-          {/* <ContentsWrapper className="cmm-modal-contents-wrapper"> */}
+        <Layout
+          className="cmm-modal-layout"
+          ref={_ref}
+          style={styles}
+          // onMouseEnter={focusContents}
+        >
           <Content
             className="cmm-modal-content"
             ref={_contentsRef}
@@ -67,7 +81,6 @@ const _ModalUIPage = (props: {
           >
             {show ? children : null}
           </Content>
-          {/* </ContentsWrapper> */}
         </Layout>
       </Items>
     </Wrapper>

--- a/src/components/modules/modal/modal.styles.ts
+++ b/src/components/modules/modal/modal.styles.ts
@@ -5,6 +5,9 @@ interface StyleTypes {
   isOpen?: boolean;
   showBGAnimation?: boolean;
   showModalOpenAnimation?: boolean;
+  mobileDefaultStyles?: { width?: string; height?: string };
+  onAnimation?: boolean;
+  hideCloseButton?: boolean;
 }
 
 export const Wrapper = styled.div`
@@ -18,7 +21,7 @@ export const Wrapper = styled.div`
   align-items: center;
   justify-content: center;
   z-index: -1;
-  transition: all 0.2s ease-out;
+  transition: all 0.3s ease-out;
 
   ${(props) =>
     props.isOpen && {
@@ -30,7 +33,12 @@ export const Wrapper = styled.div`
   transition: ${(props: StyleTypes) => !props.showBGAnimation && "unset"};
 
   transition: ${(props: StyleTypes) =>
-    props.showModalOpenAnimation && "z-index 0.2s ease-out"};
+    props.showModalOpenAnimation && "z-index .3s ease-out"};
+
+  transition: ${(props: StyleTypes) =>
+    props.showModalOpenAnimation &&
+    props.showBGAnimation &&
+    "all .3s ease-out"};
 `;
 
 export const Items = styled.div`
@@ -39,6 +47,17 @@ export const Items = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+
+  @media ${breakPoints.mobile} {
+    width: 80%;
+    height: 70%;
+
+    ${(props: StyleTypes) =>
+      props.mobileDefaultStyles && {
+        width: props.mobileDefaultStyles.width,
+        height: props.mobileDefaultStyles.height,
+      }}
+  }
 `;
 
 export const Layout = styled.div`
@@ -56,7 +75,8 @@ export const Layout = styled.div`
   }
 
   @media ${breakPoints.mobile} {
-    width: 90%;
+    width: 100%;
+    height: 100%;
   }
 `;
 
@@ -85,31 +105,47 @@ export const Content = styled.div`
   // 모달 오픈 이벤트를 설정했을 경우
   ${(props) =>
     props.showModalOpenAnimation && {
-      transition: "all 0.25s ease",
+      transition: "all .3s ease-out",
     }};
 `;
 
-export const CloseButtonWrapper = styled.div`
+export const CloseButtonWrapper = styled.button`
   display: flex;
+  align-items: center;
   justify-content: flex-end;
   position: absolute;
   top: -30px;
   right: 0;
+  opacity: 0;
+
+  ${(props: StyleTypes) =>
+    props.isOpen && {
+      opacity: 1,
+    }};
+
+  ${(props) =>
+    props.onAnimation && {
+      transition: "all .3s ease-out",
+    }};
+
+  ${(props) =>
+    props.hideCloseButton && {
+      display: "none",
+    }};
+
+  .cmm-modal-close-ment {
+    color: white;
+    margin-right: 6px;
+  }
 `;
 
-export const CloseButton = styled.button`
+export const CloseButton = styled.div`
   width: 20px;
   height: 20px;
-  background-color: unset;
-  border: unset;
   position: relative;
   display: flex;
   justify-content: center;
   align-items: center;
-
-  .cmm-unit-image {
-    object-fit: cover;
-  }
 
   :after,
   :before {

--- a/src/components/modules/modal/modal.types.ts
+++ b/src/components/modules/modal/modal.types.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject } from "react";
+import { MouseEvent, MutableRefObject } from "react";
 
 export interface ModalPropsType {
   children?: React.ReactNode;
@@ -8,10 +8,17 @@ export interface ModalPropsType {
     height?: string;
   };
   // 내부 콘텐츠 내용 스타일 지정
+  mobileDefaultStyles?: {
+    width?: string;
+    height?: string;
+  };
+  // 모바일 환경에서 적용될 스타일 지정 (767px 이하부터 적용)
   show: boolean;
   // ** 모달 실행 스위스 변수, true일 경우 실행되며 false일 경우 종료된다. (default : false)
   onCloseModal: () => void;
   // ** 모달을 종료시키는 함수
+  closeMent?: string;
+  // 닫기 버튼 앞으로 출력될 문자열
   hideCloseButton?: boolean;
   // 모달 닫기 아이콘 감추기, true일 경우 제거 (default : false)
   closeButtonSize?: string | number;
@@ -27,4 +34,5 @@ export interface ModalPropsType {
 export interface ModalPropsUITypes {
   _ref?: MutableRefObject<HTMLDivElement>;
   _contentsRef?: MutableRefObject<HTMLDivElement>;
+  focusContents?: () => void;
 }


### PR DESCRIPTION
1. Modal Module Props 추가
- mobileDefaultStyles : 모바일 (767px 이하) 접근시에 적용되는 스타일 추가
- closeMent : 닫기 버튼 앞에 출력되는 문자열
                       이에 따라 모달 닫기 레이아웃 재조정

2. _Button, _SpanText, _PText 공통 컴포넌트 생성

3. Modal MouseEvent 추가
- 모달에 마우스 enter시에 스크롤 이벤트 우선 적용 