### PR TITLE
2023-06-10 :: Modal 컴포넌트 onFixWindow props 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcm-js",
-  "version": "0.0.35",
+  "version": "0.0.37",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcm-js",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/pages/test/modal/index.tsx
+++ b/pages/test/modal/index.tsx
@@ -64,9 +64,14 @@ export default function ModalExamplePage() {
             <Modal
               show={lastOpen}
               onCloseModal={() => setLastOpen(false)}
+              onAfterCloseEvent={() => {
+                Modal.close({ id: "outer-modal" });
+                setOutOpen(false);
+              }}
               modalSize={{ width: "100px", height: "100px" }}
               showBGAnimation
               showModalOpenAnimation
+              onFixWindow
             ></Modal>
           </Modal>
         </Modal>
@@ -75,13 +80,11 @@ export default function ModalExamplePage() {
         <button
           onClick={() =>
             Modal.open({
-              onCloseModal: () => {
-                Modal.close();
-              },
               showBGAnimation: true,
               showModalOpenAnimation: true,
               id: "aaa",
               name: "test",
+              offAutoClose: true,
               children: (
                 <>111</>
                 // <button

--- a/pages/test/modal/index.tsx
+++ b/pages/test/modal/index.tsx
@@ -58,7 +58,6 @@ export default function ModalExamplePage() {
             id="inner-modal"
             showBGAnimation
             showModalOpenAnimation
-            modalStyles={{ border: "solid 2px black" }}
           >
             <button onClick={() => setLastOpen(true)}>모달 실행</button>
             <Modal

--- a/src/components/modules/modal/component/modal.container.tsx
+++ b/src/components/modules/modal/component/modal.container.tsx
@@ -18,7 +18,6 @@ export default function _Modal(
 // 2. 최종 모달 렌더 컴포넌트
 export function _RenderModal(props: ModalPropsType) {
   const {
-    id,
     show,
     offAutoClose,
     onCloseModal,
@@ -27,6 +26,7 @@ export function _RenderModal(props: ModalPropsType) {
     showBGAnimation,
     showModalOpenAnimation,
     onAfterCloseEvent,
+    onFixWindow,
   } = props;
   const _modalWrapperRef = useRef() as MutableRefObject<HTMLDivElement>;
   const _wrapperRef = useRef() as MutableRefObject<HTMLDivElement>;
@@ -38,7 +38,7 @@ export function _RenderModal(props: ModalPropsType) {
   useEffect(() => {
     if (show) {
       // 스크롤 이동 방지
-      if (document.body) document.body.style.overflow = "hidden";
+      if (document.body && onFixWindow) document.body.style.overflow = "hidden";
 
       ableClose = false;
       window.setTimeout(() => {
@@ -133,12 +133,14 @@ export function _RenderModal(props: ModalPropsType) {
 
           // 8. 스크롤 이동 가능
           if (document.body) {
-            // 실행되어 있는 여분의 모달이 있는지 검색
-            const extraModal =
-              document.getElementsByClassName("mcm-modal-wrapper");
+            window.setTimeout(() => {
+              // 실행되어 있는 여분의 모달이 있는지 검색
+              const extraModal =
+                document.getElementsByClassName("mcm-modal-wrapper");
 
-            // 실행된 모달이 하나도 없다면 스크롤 이동 가능으로 설정
-            if (!extraModal.length) document.body.style.overflow = "auto";
+              // 실행된 모달이 하나도 없다면 스크롤 이동 가능으로 설정
+              if (!extraModal.length) document.body.style.overflow = "auto";
+            }, 0);
           }
         }, 100);
       }, 0);

--- a/src/components/modules/modal/component/modal.presenter.tsx
+++ b/src/components/modules/modal/component/modal.presenter.tsx
@@ -46,6 +46,9 @@ const ModalUIPage = (props: {
   const closeBtnTop =
     `-${Number(_closeButtonSize.split("px")[0]) + 10}px` || "-25px";
 
+  const buttonWrapperStyles = modalStyles?.closeButton || {};
+  buttonWrapperStyles.top = closeBtnTop;
+
   return (
     <_Error
       propsList={_props}
@@ -63,6 +66,7 @@ const ModalUIPage = (props: {
             data-name={name}
             onMouseDown={handleClickEvent}
             ref={_wrapperRef}
+            style={modalStyles?.wrapper || {}}
           >
             <Items
               className={modalClassList.items}
@@ -71,12 +75,12 @@ const ModalUIPage = (props: {
               showModalOpenAnimation={showModalOpenAnimation}
               isOpen={show}
               ref={_itemRef}
-              style={modalStyles}
+              style={modalStyles?.items || {}}
             >
               <CloseButtonWrapper
                 className={modalClassList.closeButtonWrapper}
                 isOpen={show}
-                style={{ top: closeBtnTop }}
+                style={buttonWrapperStyles}
                 closeMent={closeMent}
               >
                 <_Button
@@ -104,6 +108,7 @@ const ModalUIPage = (props: {
               <ContentsWrapper
                 className={modalClassList.contents}
                 ref={_contentsRef}
+                style={modalStyles?.contents || {}}
               >
                 {show ? children : undefined}
               </ContentsWrapper>

--- a/src/components/modules/modal/component/modal.types.ts
+++ b/src/components/modules/modal/component/modal.types.ts
@@ -14,8 +14,13 @@ export interface ModalPropsType {
     width?: string;
     height?: string;
   };
-  // 모달에 적용되는 스타일
-  modalStyles?: CSSProperties;
+  // 모달에 적용되는 스타일, 각각의 태그 별로 설정이 가능하다.
+  modalStyles?: {
+    wrapper?: CSSProperties;
+    items?: CSSProperties;
+    closeButton?: CSSProperties;
+    contents?: CSSProperties;
+  };
   // 모달 사이즈 (width, height) 지정
   mobileModalSize?: {
     width?: string;

--- a/src/components/modules/modal/component/modal.types.ts
+++ b/src/components/modules/modal/component/modal.types.ts
@@ -48,6 +48,8 @@ export interface ModalPropsType {
   // state 렌더가 아닌 window 형식의 오픈시 제거할 id 값
   onAfterCloseEvent?: () => void;
   // 모달이 종료된 다음 시점에 실행될 이벤트
+  onFixWindow?: boolean;
+  // 모달이 열려있는 상태에서 스크롤 이동을 방지할 건지에 대한 여부
 }
 
 export interface ModalPropsUITypes {


### PR DESCRIPTION
1. 모달 오픈시 스크롤 이동 방지 기능을 on/off 할 수 있도록 onFixWindow props 추가
  - 해당 props가 전달되어야만 스크롤 이동 방지를 사용할 수 있도록 설정
2. 기존의 스크롤 이동 방지 기능을 설정할 때 onAfterCloseEvent 이벤트로 Modal.close 함수를 실행할 경우 body style의 overflow의 hidden이 해제되지 않는 현상 수정 완료 
  - setTimeout 함수를 통해 스크롤 이동 해제의 순서를 후 순서로 이동