### PR TITLE
2023-06-20 :: 말풍선(Tooltip) 모듈 초기셋팅 완료 및 1차 구현 완료

### DIFF
--- a/pages/test/test/index.tsx
+++ b/pages/test/test/index.tsx
@@ -1,9 +1,0 @@
-import React from "react";
-
-export default function Test() {
-  return (
-    <div>
-      <div></div>
-    </div>
-  );
-}

--- a/pages/test/tooltip/index.tsx
+++ b/pages/test/tooltip/index.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import _Tootip from "../../../src/components/modules/tooltip/component/tooltip.container";
+
+export default function Test() {
+  return (
+    <div>
+      <div></div>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          paddingTop: "200px",
+        }}
+      >
+        <div>qqqqqqqq</div>
+        <div>
+          <_Tootip tooltipText={<div>1111231231231</div>} useShowAnimation>
+            <div>
+              <h1 style={{ margin: "0px" }}>gggggggggg</h1>
+              <div>222</div>
+              {/* <img src="https://us.123rf.com/450wm/mblach/mblach1402/mblach140200030/25799171-%EC%82%AC%EA%B3%BC.jpg" /> */}
+            </div>
+          </_Tootip>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/modules/tooltip/component/tooltip.container.tsx
+++ b/src/components/modules/tooltip/component/tooltip.container.tsx
@@ -1,0 +1,183 @@
+import styled from "@emotion/styled";
+
+import { _Error } from "mcm-js-commons";
+import {
+  CSSProperties,
+  MutableRefObject,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+import { TooltipPropsType } from "./tooltip.types";
+
+let deboucing: number | ReturnType<typeof setTimeout>;
+let loading = false;
+// 추가 설명을 위한 말풍선 모듈
+export default function _Tooltip(props: TooltipPropsType) {
+  // 말풍선 ref
+  const tailRef = useRef() as MutableRefObject<HTMLDivElement>;
+  const { children, tooltipText, useShowAnimation } = props;
+
+  // 말풍선 보이기
+  const [show, setShow] = useState(false);
+
+  // 마우스 hover시 말풍선 오픈
+  const toggleTail = (bool: boolean) => async () => {
+    if (bool === show || loading) return;
+
+    // 스테이트 변환 시간
+    let timer = 0;
+
+    // 말풍선 애니메이션을 사용한다면
+    if (useShowAnimation) {
+      // 말풍선을 닫는다면
+      if (!bool) {
+        loading = true; // 중복 실행 방지
+        timer = 250; // 변환 시간 지연
+
+        if (tailRef && tailRef.current) {
+          tailRef.current.style.animation = "CLOSE_TOOLTIP  0.3s";
+        }
+      }
+    }
+
+    // 말풍선을 닫을 경우
+    window.setTimeout(() => {
+      setShow(bool);
+      loading = false;
+    }, timer);
+  };
+
+  return (
+    <_Error
+      propsList={{ children, tooltipText }}
+      requiredList={["children", "tooltipText"]}
+    >
+      <TooltipWrapper
+        className="mcm-tooltip-wrapper"
+        onMouseLeave={toggleTail(false)}
+      >
+        <TooltipItems className="mcm-tooltip-items">
+          <TooltipLayout
+            className="mcm-tooltip-layout"
+            onMouseOver={toggleTail(true)}
+          >
+            {children}
+          </TooltipLayout>
+          {(show && (
+            <TooltipTailWrapper
+              className="mcm-tooltip-tail-wrapper"
+              ref={tailRef}
+              useShowAnimation={useShowAnimation}
+              show={show}
+            >
+              <TooltipTailContents className="mcm-tooltip-tail-contents">
+                {tooltipText}
+              </TooltipTailContents>
+            </TooltipTailWrapper>
+          )) || <></>}
+        </TooltipItems>
+      </TooltipWrapper>
+    </_Error>
+  );
+}
+
+interface StyleTypes {
+  // 말풍선 실행 애니메이션
+  useShowAnimation?: boolean;
+  show?: boolean;
+}
+
+export const TooltipWrapper = styled.div`
+  display: inline-block;
+  cursor: default;
+`;
+
+export const TooltipItems = styled.div`
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  align-items: center;
+  justify-content: flex-start;
+`;
+
+export const TooltipLayout = styled.div`
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  position: relative;
+`;
+
+export const TooltipTailWrapper = styled.div`
+  position: absolute;
+  border: solid 1px black;
+  border-radius: 10px;
+  background-color: white;
+  min-width: 40px;
+  transform: translateY(-3.2rem);
+  animation-fill-mode: forwards;
+  animation-direction: alternate;
+
+  @keyframes SHOW_TOOLTIP {
+    from {
+      opacity: 0;
+      transform: translateY(-2.5rem);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(-3.2rem);
+    }
+  }
+
+  @keyframes CLOSE_TOOLTIP {
+    from {
+      opacity: 1;
+      transform: translateY(-3.2rem);
+    }
+    to {
+      opacity: 0;
+      transform: translateY(-2.5rem);
+    }
+  }
+
+  ${(props: StyleTypes) => {
+    const styles: { [key: string]: string } & CSSProperties = {};
+
+    // 실행 애니메이션을 사용하는 경우
+    if (props.useShowAnimation) {
+      styles.transition = "all 0.3s";
+
+      if (props.show) {
+        // 실행 애니메이션 스타일 적용
+        styles.animation = "SHOW_TOOLTIP 0.3s";
+      }
+    }
+
+    return styles;
+  }}
+`;
+
+export const TooltipTailContents = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  padding: 12px;
+  width: 100%;
+
+  ::after,
+  ::before {
+    position: absolute;
+    content: "";
+    width: 18px;
+    height: 14px;
+    background-color: #ffff;
+    border-radius: 4px;
+    box-shadow: -1px 1px black;
+    transform: rotate(-40deg);
+    position: absolute;
+    z-index: 2;
+    bottom: -5.5px;
+  }
+`;

--- a/src/components/modules/tooltip/component/tooltip.types.ts
+++ b/src/components/modules/tooltip/component/tooltip.types.ts
@@ -1,0 +1,8 @@
+export interface TooltipPropsType {
+  // 말풍선 사이에 렌더될 내용
+  children: React.ReactNode;
+  // 말풍선 내용
+  tooltipText: string | React.ReactNode;
+  // 말풍선 실행 애니메이션 사용 여부, true 전달하면 적용됨 (default : false)
+  useShowAnimation?: boolean;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -12,12 +16,18 @@
     //////// 변경 내용 ////////
     "noEmit": false,
     "module": "CommonJS",
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "declaration": true,
     "outDir": "./dist",
     ////////////////////////
     "incremental": true
   },
-  "include": ["next-env.d.ts", "src/**/*.tsx", "src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "src/**/*.tsx",
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
1. 기존의 title 속성을 대체해서 사용할 수 있는 Tooltip 모듈 구현 계획 완료
-  마우스 호버시에 추가적인 설명을 덫붙일 수 있는 모듈
2. 추가 설명을 붙일 컴포넌트를 children props로 받으며 해당 children을 호버했을 때 실행
3. tooltipText를 통해 설명하려는 텍스트나 컴포넌트를 전달할 수 있음.
-  **children과 tooltipText는 필수 데이터**이며, 전달되지 않을 경우 에러메세지 출력
4. **useShowAnimation** props를 통해 말풍선을 실행하거나 종료할 때 애니메이션을 적용할 건지를 설정할 수 있음