### PR TITLE
2023-06-21 :: 말풍선(Tooltip) 실행 및 종료 방식 변경 및 position, isDisable props 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mcm-js",
-  "version": "0.0.39",
+  "name": "mcm-js-dev",
+  "version": "0.0.26",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/pages/test/tooltip/index.tsx
+++ b/pages/test/tooltip/index.tsx
@@ -1,7 +1,8 @@
-import React from "react";
-import _Tootip from "../../../src/components/modules/tooltip/component/tooltip.container";
+import React, { useState } from "react";
+import _Tooltip from "../../../src/components/modules/tooltip/component/tooltip.container";
 
 export default function Test() {
+  const [disAble, setDisAble] = useState(false);
   return (
     <div>
       <div></div>
@@ -14,17 +15,51 @@ export default function Test() {
           paddingTop: "200px",
         }}
       >
-        <div>qqqqqqqq</div>
-        <div>
-          <_Tootip tooltipText={<div>1111231231231</div>} useShowAnimation>
+        <div style={{ display: "flex", gap: "0px 20px" }}>
+          <_Tooltip
+            tooltipText="open1"
+            useShowAnimation
+            position={{ top: "-100px" }}
+          >
+            📌
+          </_Tooltip>
+          <_Tooltip
+            tooltipText="open2"
+            useShowAnimation
+            position={{ top: "-50px" }}
+          >
+            <div>오픈 2</div>
+          </_Tooltip>
+          <_Tooltip
+            tooltipText="open3"
+            useShowAnimation
+            position={{ top: "-10px" }}
+          >
+            <div>오픈 3</div>
+          </_Tooltip>
+        </div>
+
+        {/* <div>qqqqqqqq</div> */}
+        <div style={{ marginTop: "50px" }}>
+          <_Tooltip
+            tooltipText="안녕하세요?"
+            useShowAnimation
+            isDisable={disAble}
+          >
             <div>
-              <h1 style={{ margin: "0px" }}>gggggggggg</h1>
-              <div>222</div>
-              {/* <img src="https://us.123rf.com/450wm/mblach/mblach1402/mblach140200030/25799171-%EC%82%AC%EA%B3%BC.jpg" /> */}
+              {/* 말풍선 오픈하기 */}
+              {/* <span>말풍선 오픈하기</span> */}
+              {/* <h1 style={{ margin: "0px" }}>말풍선 오픈하기</h1> */}
+              <img src="https://us.123rf.com/450wm/mblach/mblach1402/mblach140200030/25799171-%EC%82%AC%EA%B3%BC.jpg" />
             </div>
-          </_Tootip>
+          </_Tooltip>
         </div>
       </div>
+      <button onClick={() => setDisAble((prev) => !prev)}>
+        말풍선 {disAble ? "on" : "off"}
+      </button>
     </div>
   );
 }
+//
+//

--- a/src/components/modules/modal/index.tsx
+++ b/src/components/modules/modal/index.tsx
@@ -2,7 +2,6 @@ import OriginModal from "./component/modal.container";
 import { ModalType } from "./component/modal.types";
 import { openModal, closeModal } from "./func";
 
-// window로 open할 경우 삭제할 수 있는 id값 설정
 const Modal = OriginModal as ModalType;
 
 // 모달 오픈 함수

--- a/src/components/modules/tooltip/component/tooltip.presenter.tsx
+++ b/src/components/modules/tooltip/component/tooltip.presenter.tsx
@@ -1,0 +1,44 @@
+import {
+  TooltipItems,
+  TooltipLayout,
+  TooltipTailContents,
+  TooltipTailWrapper,
+  TooltipWrapper,
+} from "./tooltip.styles";
+
+import { TooltipPropsType, TooltipUIPropsType } from "./tooltip.types";
+
+export default function _TooltipUIPage(
+  props: TooltipPropsType & TooltipUIPropsType
+) {
+  const { children, tooltipText, useShowAnimation, show, toggleTail, tailRef } =
+    props;
+
+  return (
+    <TooltipWrapper
+      className="mcm-tooltip-wrapper"
+      onMouseLeave={toggleTail(false)}
+    >
+      <TooltipItems className="mcm-tooltip-items">
+        <TooltipLayout
+          className="mcm-tooltip-layout"
+          onMouseOver={toggleTail(true)}
+        >
+          {children}
+        </TooltipLayout>
+        {(show && (
+          <TooltipTailWrapper
+            className="mcm-tooltip-tail-wrapper"
+            ref={tailRef}
+            useShowAnimation={useShowAnimation}
+            show={show}
+          >
+            <TooltipTailContents className="mcm-tooltip-tail-contents">
+              {tooltipText}
+            </TooltipTailContents>
+          </TooltipTailWrapper>
+        )) || <></>}
+      </TooltipItems>
+    </TooltipWrapper>
+  );
+}

--- a/src/components/modules/tooltip/component/tooltip.styles.ts
+++ b/src/components/modules/tooltip/component/tooltip.styles.ts
@@ -1,0 +1,107 @@
+import styled from "@emotion/styled";
+import { CSSProperties } from "react";
+
+interface StyleTypes {
+  // 말풍선 실행 애니메이션
+  useShowAnimation?: boolean;
+  show?: boolean;
+  positionTop?: number;
+}
+
+export const TooltipWrapper = styled.div`
+  display: inline-block;
+  cursor: default;
+`;
+
+export const TooltipItems = styled.div`
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  align-items: center;
+  justify-content: flex-start;
+`;
+
+export const TooltipLayout = styled.div`
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  position: relative;
+`;
+
+export const TooltipTailWrapper = styled.div`
+  position: absolute;
+  border: solid 1px black;
+  border-radius: 10px;
+  background-color: white;
+  min-width: 40px;
+  /* margin-top: ${(props) => `${props.positionTop}px`}; */
+  animation-fill-mode: forwards;
+  animation-direction: alternate;
+
+  // 애니메이션용 margin-top
+  --move-start-positionTop: -30;
+  --move-end-positionTop: -20;
+
+  @keyframes SHOW_TOOLTIP {
+    from {
+      opacity: 0;
+      margin-top: var(--move-start-positionTop);
+    }
+    to {
+      opacity: 1;
+      margin-top: var(--move-end-positionTop);
+    }
+  }
+
+  @keyframes CLOSE_TOOLTIP {
+    from {
+      opacity: 1;
+      margin-top: var(--move-end-positionTop);
+    }
+    to {
+      opacity: 0;
+      margin-top: var(--move-start-positionTop);
+    }
+  }
+
+  ${(props: StyleTypes) => {
+    const styles: { [key: string]: string } & CSSProperties = {};
+
+    // 실행 애니메이션을 사용하는 경우
+    if (props.useShowAnimation) {
+      styles.transition = "all 0.3s";
+
+      if (props.show) {
+        // 실행 애니메이션 스타일 적용
+        styles.animation = "SHOW_TOOLTIP 0.3s";
+      }
+    }
+
+    return styles;
+  }}
+`;
+
+export const TooltipTailContents = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  padding: 6px;
+  width: 100%;
+  white-space: pre;
+  font-size: 12px;
+
+  ::after {
+    position: absolute;
+    content: "";
+    width: 12px;
+    height: 16px;
+    background-color: #ffff;
+    border-radius: 4px;
+    box-shadow: -1px 1px black;
+    transform: rotate(-55deg);
+    position: absolute;
+    z-index: 2;
+    bottom: -6.5px;
+  }
+`;

--- a/src/components/modules/tooltip/component/tooltip.types.ts
+++ b/src/components/modules/tooltip/component/tooltip.types.ts
@@ -1,3 +1,6 @@
+import { MutableRefObject } from "react";
+import _Tooltip from "./tooltip.container";
+
 export interface TooltipPropsType {
   // 말풍선 사이에 렌더될 내용
   children: React.ReactNode;
@@ -5,4 +8,19 @@ export interface TooltipPropsType {
   tooltipText: string | React.ReactNode;
   // 말풍선 실행 애니메이션 사용 여부, true 전달하면 적용됨 (default : false)
   useShowAnimation?: boolean;
+  // 말풍선 위치
+  position?: {
+    top?: string; // 위
+    // left?: string; // 왼쪽
+  };
+  // 비활성화 여부, true를 전달하면 말풍선을 사용하지 않는다. (default : false)
+  isDisable?: boolean;
 }
+
+export interface TooltipUIPropsType {
+  show: boolean; // 말풍선 보이기 여부
+  toggleTail: (bool: boolean) => () => void;
+  tailRef: MutableRefObject<HTMLDivElement>;
+}
+
+export type TooltipType = typeof _Tooltip;

--- a/src/components/modules/tooltip/index.tsx
+++ b/src/components/modules/tooltip/index.tsx
@@ -1,0 +1,6 @@
+import _Tooltip from "./component/tooltip.container";
+import { TooltipType } from "./component/tooltip.types";
+
+const Tooltip = _Tooltip as TooltipType;
+
+export default Tooltip;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 // import Modal from "./components/modules/modal/modal.container";
 import Modal from "./components/modules/modal";
+import Tooltip from "./components/modules/tooltip";
 
-export { Modal };
+export { Modal, Tooltip };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -16,18 +12,12 @@
     //////// 변경 내용 ////////
     "noEmit": false,
     "module": "CommonJS",
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "declaration": true,
     "outDir": "./dist",
     ////////////////////////
     "incremental": true
   },
-  "include": [
-    "next-env.d.ts",
-    "src/**/*.tsx",
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "src/**/*.tsx", "src/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
1. 여러개의 Tooltip 모듈이 설정되어 있는 상태에서 useShowAnimation props를 다중으로 사용할 경우 마우스 호버시에 0.2초 간격의 딜레이가 적용되어 뚝뚝 끊기는 현상이 발견, 원인을 파악해보니 중복 실행을 방지하는 loading 변수가 컴포넌트 밖에서 선언되어 전체의 모듈이 영향을 받는 것으로 확인되어 loading 변수를 컴포넌트 안쪽으로 이동해 각각의 컴포넌트들이 제어할 수 있도록 변경함
2. position props를 전달받아 말풍선의 시작 및 종료 위치를 사용자가 직접 변경할 수 있도록 추가
3. 위의 position props를 추가함에 따라 기존의 Animation 속성에서도 props 형태로 전달 받는 형식이 아니라 말풍선을 실행하는 시점에서 시작 위치와 종료 위치를 실시간으로 전달하는 방식으로 변경 (여러개의 Animation 속성이 중복되는 현상을 방지하기 위해)
4. isDisable props를 추가해 원하는 시점에서는 말풍선을 실행하지 않도록 추가