### PR TITLE
2023-06-23 :: Modal 종료시 overflow 이슈 수정 및 Tooltip id, className props 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mcm-js-dev",
-  "version": "0.0.26",
+  "name": "mcm-js",
+  "version": "0.0.41",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/commons/types/commons.types.ts
+++ b/src/commons/types/commons.types.ts
@@ -1,0 +1,19 @@
+// className과 id 타입
+export interface CommonsSelectorTypes {
+  className?: string;
+  // wrapper에 삽입될 className
+  id?: string;
+  // wrapper에 삽입될 id
+}
+
+// children 타입, optional로 할 경우에는 Partial을 추가한다.
+export interface CommonsChildrenTypes {
+  children: React.ReactNode;
+  // 렌더될 하위 컴포넌트, 디폴트 값으로 설정되며 Component가 있으면 Component를 렌더한다.
+}
+
+// name 타입
+export interface CommonsNameTypes {
+  name?: string;
+  // wrapper에 삽입될 data-name
+}

--- a/src/commons/types/index.ts
+++ b/src/commons/types/index.ts
@@ -1,3 +1,4 @@
 import { ModalPropsType } from "../../components/modules/modal/component/modal.types";
+import { TooltipPropsType } from "../../components/modules/tooltip/component/tooltip.types";
 
-export type { ModalPropsType };
+export type { ModalPropsType, TooltipPropsType };

--- a/src/components/modules/modal/component/modal.container.tsx
+++ b/src/components/modules/modal/component/modal.container.tsx
@@ -66,6 +66,8 @@ export function _RenderModal(props: ModalPropsType) {
           _itemRef.current?.classList.add(modalFuncClass.itemShow);
         }
       }, 0);
+    } else {
+      disableOverflow();
     }
 
     if (_itemRef) {
@@ -93,6 +95,14 @@ export function _RenderModal(props: ModalPropsType) {
         }, (showModalOpenAnimation && 200) || 0);
     }
   }, [show]);
+
+  const disableOverflow = () => {
+    // 실행되어 있는 여분의 모달이 있는지 검색
+    const extraModal = document.getElementsByClassName("mcm-modal-wrapper");
+
+    // 실행된 모달이 하나도 없다면 스크롤 이동 가능으로 설정
+    if (!extraModal.length) document.body.style.overflow = "auto";
+  };
 
   // 모달 닫기 이벤트 실행
   const _onCloseModal = async () => {
@@ -135,11 +145,7 @@ export function _RenderModal(props: ModalPropsType) {
           if (document.body) {
             window.setTimeout(() => {
               // 실행되어 있는 여분의 모달이 있는지 검색
-              const extraModal =
-                document.getElementsByClassName("mcm-modal-wrapper");
-
-              // 실행된 모달이 하나도 없다면 스크롤 이동 가능으로 설정
-              if (!extraModal.length) document.body.style.overflow = "auto";
+              disableOverflow();
             }, 0);
           }
         }, 100);

--- a/src/components/modules/modal/component/modal.types.ts
+++ b/src/components/modules/modal/component/modal.types.ts
@@ -1,61 +1,61 @@
 import { CSSProperties, MouseEvent, MutableRefObject } from "react";
 import OriginModal from "./modal.container";
 
-export interface ModalPropsType {
-  children?: React.ReactNode;
-  // 렌더될 하위 컴포넌트, 디폴트 값으로 설정되며 Component가 있으면 Component를 렌더한다.
-  className?: string;
-  // wrapper에 삽입될 className
-  id?: string;
-  // wrapper에 삽입될 id
-  name?: string;
-  // wrapper에 삽입될 data-name
-  modalSize?: {
-    width?: string;
-    height?: string;
+import {
+  CommonsChildrenTypes,
+  CommonsSelectorTypes,
+  CommonsNameTypes,
+} from "../../../../commons/types/commons.types";
+
+export type ModalPropsType = CommonsSelectorTypes &
+  Partial<CommonsChildrenTypes> &
+  CommonsNameTypes & {
+    modalSize?: {
+      width?: string;
+      height?: string;
+    };
+    // 모달에 적용되는 스타일, 각각의 태그 별로 설정이 가능하다.
+    modalStyles?: {
+      wrapper?: CSSProperties;
+      items?: CSSProperties;
+      closeButton?: CSSProperties;
+      contents?: CSSProperties;
+    };
+    // 모달 사이즈 (width, height) 지정
+    mobileModalSize?: {
+      width?: string;
+      height?: string;
+    };
+    // 모바일 환경에서 적용될 사이즈 (width, height) 지정 (767px 이하부터 적용)
+    show: boolean;
+    // ** 모달 실행 스위스 변수, true일 경우 실행되며 false일 경우 종료된다. (default : false)
+    onCloseModal: () => void;
+    // ** 모달을 종료시키는 함수
+    closeMent?: string;
+    // 닫기 버튼 앞으로 출력될 문자열
+    hideCloseButton?: boolean;
+    // 모달 닫기 아이콘 감추기, true일 경우 제거 (default : false)
+    offAutoClose?: boolean;
+    // 모달 외의 영역을 클릭했을 때 모달이 종료되지 않게 설정 (default : false)
+    showBGAnimation?: boolean;
+    // 모달 실행시 배경화면 애니메이션 작동 (default : false)
+    showModalOpenAnimation?: boolean;
+    // 모달 실행시 모달창 오픈 애니메이션 작동 (default : false)
+    closeButtonInfo?: {
+      buttonSize?: string | number;
+      buttonWeight?: string | number;
+      buttonColor?: string;
+    };
+    // 닫기 버튼에 관한 사이즈, 굵기, 색상에 대한 설정
+    _wmo?: boolean;
+    // (window modal open) window 형식의 오픈 여부
+    openIdx?: number;
+    // state 렌더가 아닌 window 형식의 오픈시 제거할 id 값
+    onAfterCloseEvent?: () => void;
+    // 모달이 종료된 다음 시점에 실행될 이벤트
+    onFixWindow?: boolean;
+    // 모달이 열려있는 상태에서 스크롤 이동을 방지할 건지에 대한 여부
   };
-  // 모달에 적용되는 스타일, 각각의 태그 별로 설정이 가능하다.
-  modalStyles?: {
-    wrapper?: CSSProperties;
-    items?: CSSProperties;
-    closeButton?: CSSProperties;
-    contents?: CSSProperties;
-  };
-  // 모달 사이즈 (width, height) 지정
-  mobileModalSize?: {
-    width?: string;
-    height?: string;
-  };
-  // 모바일 환경에서 적용될 사이즈 (width, height) 지정 (767px 이하부터 적용)
-  show: boolean;
-  // ** 모달 실행 스위스 변수, true일 경우 실행되며 false일 경우 종료된다. (default : false)
-  onCloseModal: () => void;
-  // ** 모달을 종료시키는 함수
-  closeMent?: string;
-  // 닫기 버튼 앞으로 출력될 문자열
-  hideCloseButton?: boolean;
-  // 모달 닫기 아이콘 감추기, true일 경우 제거 (default : false)
-  offAutoClose?: boolean;
-  // 모달 외의 영역을 클릭했을 때 모달이 종료되지 않게 설정 (default : false)
-  showBGAnimation?: boolean;
-  // 모달 실행시 배경화면 애니메이션 작동 (default : false)
-  showModalOpenAnimation?: boolean;
-  // 모달 실행시 모달창 오픈 애니메이션 작동 (default : false)
-  closeButtonInfo?: {
-    buttonSize?: string | number;
-    buttonWeight?: string | number;
-    buttonColor?: string;
-  };
-  // 닫기 버튼에 관한 사이즈, 굵기, 색상에 대한 설정
-  _wmo?: boolean;
-  // (window modal open) window 형식의 오픈 여부
-  openIdx?: number;
-  // state 렌더가 아닌 window 형식의 오픈시 제거할 id 값
-  onAfterCloseEvent?: () => void;
-  // 모달이 종료된 다음 시점에 실행될 이벤트
-  onFixWindow?: boolean;
-  // 모달이 열려있는 상태에서 스크롤 이동을 방지할 건지에 대한 여부
-}
 
 export interface ModalPropsUITypes {
   _modalWrapperRef?: MutableRefObject<HTMLDivElement>;

--- a/src/components/modules/tooltip/component/tooltip.presenter.tsx
+++ b/src/components/modules/tooltip/component/tooltip.presenter.tsx
@@ -5,18 +5,28 @@ import {
   TooltipTailWrapper,
   TooltipWrapper,
 } from "./tooltip.styles";
+import { getAllComponentsClassName } from "mcm-js-commons/dist/hooks";
 
 import { TooltipPropsType, TooltipUIPropsType } from "./tooltip.types";
 
 export default function _TooltipUIPage(
   props: TooltipPropsType & TooltipUIPropsType
 ) {
-  const { children, tooltipText, useShowAnimation, show, toggleTail, tailRef } =
-    props;
+  const {
+    children,
+    className,
+    id,
+    tooltipText,
+    useShowAnimation,
+    show,
+    toggleTail,
+    tailRef,
+  } = props;
 
   return (
     <TooltipWrapper
-      className="mcm-tooltip-wrapper"
+      className={getAllComponentsClassName("mcm-tooltip-wrapper", className)}
+      id={id}
       onMouseLeave={toggleTail(false)}
     >
       <TooltipItems className="mcm-tooltip-items">

--- a/src/components/modules/tooltip/component/tooltip.styles.ts
+++ b/src/components/modules/tooltip/component/tooltip.styles.ts
@@ -26,6 +26,7 @@ export const TooltipLayout = styled.div`
   align-items: flex-end;
   justify-content: center;
   position: relative;
+  width: 100%;
 `;
 
 export const TooltipTailWrapper = styled.div`

--- a/src/components/modules/tooltip/component/tooltip.types.ts
+++ b/src/components/modules/tooltip/component/tooltip.types.ts
@@ -1,21 +1,25 @@
 import { MutableRefObject } from "react";
 import _Tooltip from "./tooltip.container";
 
-export interface TooltipPropsType {
-  // 말풍선 사이에 렌더될 내용
-  children: React.ReactNode;
-  // 말풍선 내용
-  tooltipText: string | React.ReactNode;
-  // 말풍선 실행 애니메이션 사용 여부, true 전달하면 적용됨 (default : false)
-  useShowAnimation?: boolean;
-  // 말풍선 위치
-  position?: {
-    top?: string; // 위
-    // left?: string; // 왼쪽
+import {
+  CommonsChildrenTypes,
+  CommonsSelectorTypes,
+} from "../../../../commons/types/commons.types";
+
+export type TooltipPropsType = CommonsChildrenTypes &
+  CommonsSelectorTypes & {
+    // 말풍선 내용
+    tooltipText: string | React.ReactNode;
+    // 말풍선 실행 애니메이션 사용 여부, true 전달하면 적용됨 (default : false)
+    useShowAnimation?: boolean;
+    // 말풍선 위치
+    position?: {
+      top?: string; // 위
+      // left?: string; // 왼쪽
+    };
+    // 비활성화 여부, true를 전달하면 말풍선을 사용하지 않는다. (default : false)
+    isDisable?: boolean;
   };
-  // 비활성화 여부, true를 전달하면 말풍선을 사용하지 않는다. (default : false)
-  isDisable?: boolean;
-}
 
 export interface TooltipUIPropsType {
   show: boolean; // 말풍선 보이기 여부


### PR DESCRIPTION
1. 기존에 onFixWindow를 사용하고, 직접적으로 state 값을 변경해서 모달을 종료할 경우 overflow : hidden 스타일이 해제되지 않는 이슈 수정 -> show 값이 false일 경우 overflow를 auto로 변경하는 코드 추가
2. Tooltip 모듈에 id와 className props를 추가하여 선택자를 지정할 수 있음