### PR TITLE
2023-06-27 :: Tooltip (말풍선) position, tooltipStyles, showMobile props 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcm-js",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -19,7 +19,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "mcm-js-commons": "^0.0.43",
+    "mcm-js-commons": "^0.0.64",
     "next": "^13.3.0",
     "react": "18.2.0",
     "react-dom": "^18.2.0",

--- a/pages/test/tooltip/index.tsx
+++ b/pages/test/tooltip/index.tsx
@@ -15,7 +15,14 @@ export default function Test() {
           paddingTop: "200px",
         }}
       >
-        <div style={{ display: "flex", gap: "0px 20px" }}>
+        <div
+          style={{
+            display: "flex",
+            gap: "0px 20px",
+            height: "20px",
+            overflow: "hidden",
+          }}
+        >
           <_Tooltip
             tooltipText="open1"
             useShowAnimation

--- a/pages/test/tooltip/index.tsx
+++ b/pages/test/tooltip/index.tsx
@@ -19,29 +19,49 @@ export default function Test() {
           style={{
             display: "flex",
             gap: "0px 20px",
-            height: "20px",
-            overflow: "hidden",
           }}
         >
           <_Tooltip
-            tooltipText="open1"
+            tooltipText={
+              <div>
+                <div>1</div>
+                <div>1</div>
+                <div>1</div>
+                <div>1</div>
+                <div>1</div>
+                <div>1</div>
+                <div>1</div>
+                <div>1</div>
+                <div>1</div>
+                <div>1</div>
+              </div>
+            }
             useShowAnimation
-            position={{ top: "-100px" }}
+            tooltipStyles={{
+              backgroundColor: "red",
+              // border: {
+              //   width: "10px",
+              // },
+            }}
+            position="right"
+            showMobile
           >
             📌
           </_Tooltip>
           <_Tooltip
-            tooltipText="open2"
-            useShowAnimation
-            position={{ top: "-50px" }}
+            tooltipText={
+              <img src="https://us.123rf.com/450wm/mblach/mblach1402/mblach140200030/25799171-%EC%82%AC%EA%B3%BC.jpg" />
+            }
+            // useShowAnimation
+            position="bottom"
+            tooltipStyles={{
+              backgroundColor: "red",
+            }}
+            isDisable
           >
             <div>오픈 2</div>
           </_Tooltip>
-          <_Tooltip
-            tooltipText="open3"
-            useShowAnimation
-            position={{ top: "-10px" }}
-          >
+          <_Tooltip tooltipText="open3" useShowAnimation isDisable>
             <div>오픈 3</div>
           </_Tooltip>
         </div>
@@ -49,15 +69,15 @@ export default function Test() {
         {/* <div>qqqqqqqq</div> */}
         <div style={{ marginTop: "50px" }}>
           <_Tooltip
-            tooltipText="안녕하세요?"
-            useShowAnimation
-            isDisable={disAble}
+            tooltipText="안녕하세요? 1231312312312312"
+            // isDisable={disAble}
+            isDisable
           >
             <div>
               {/* 말풍선 오픈하기 */}
               {/* <span>말풍선 오픈하기</span> */}
               {/* <h1 style={{ margin: "0px" }}>말풍선 오픈하기</h1> */}
-              <img src="https://us.123rf.com/450wm/mblach/mblach1402/mblach140200030/25799171-%EC%82%AC%EA%B3%BC.jpg" />
+              {/* <img src="https://us.123rf.com/450wm/mblach/mblach1402/mblach140200030/25799171-%EC%82%AC%EA%B3%BC.jpg" /> */}
             </div>
           </_Tooltip>
         </div>

--- a/src/components/modules/modal/component/modal.styles.ts
+++ b/src/components/modules/modal/component/modal.styles.ts
@@ -67,7 +67,7 @@ export const Items = styled.div`
     };
   }}
 
-  @media ${breakPoints.mobile} {
+  @media ${breakPoints.mobileLarge} {
     width: 80% !important;
     height: 70% !important;
 

--- a/src/components/modules/tooltip/component/tooltip.presenter.tsx
+++ b/src/components/modules/tooltip/component/tooltip.presenter.tsx
@@ -21,6 +21,10 @@ export default function _TooltipUIPage(
     show,
     toggleTail,
     tailRef,
+    render,
+    tooltipStyles,
+    position,
+    showMobile,
   } = props;
 
   return (
@@ -41,9 +45,16 @@ export default function _TooltipUIPage(
             className="mcm-tooltip-tail-wrapper"
             ref={tailRef}
             useShowAnimation={useShowAnimation}
-            show={show}
+            show={render}
+            tooltipStyles={tooltipStyles}
+            showMobile={showMobile}
+            position={position || "top"}
           >
-            <TooltipTailContents className="mcm-tooltip-tail-contents">
+            <TooltipTailContents
+              className="mcm-tooltip-tail-contents"
+              tooltipStyles={tooltipStyles}
+              position={position || "top"}
+            >
               {tooltipText}
             </TooltipTailContents>
           </TooltipTailWrapper>

--- a/src/components/modules/tooltip/component/tooltip.styles.ts
+++ b/src/components/modules/tooltip/component/tooltip.styles.ts
@@ -35,7 +35,6 @@ export const TooltipTailWrapper = styled.div`
   border-radius: 10px;
   background-color: white;
   min-width: 40px;
-  /* margin-top: ${(props) => `${props.positionTop}px`}; */
   animation-fill-mode: forwards;
   animation-direction: alternate;
 

--- a/src/components/modules/tooltip/component/tooltip.styles.ts
+++ b/src/components/modules/tooltip/component/tooltip.styles.ts
@@ -1,11 +1,16 @@
 import styled from "@emotion/styled";
 import { CSSProperties } from "react";
+import { breakPoints } from "mcm-js-commons/dist/responsive";
+
+import { TooltipStylesTypes, TooltipPositionType } from "./tooltip.types";
 
 interface StyleTypes {
   // 말풍선 실행 애니메이션
   useShowAnimation?: boolean;
   show?: boolean;
-  positionTop?: number;
+  tooltipStyles?: TooltipStylesTypes;
+  position?: TooltipPositionType;
+  showMobile?: boolean;
 }
 
 export const TooltipWrapper = styled.div`
@@ -37,48 +42,107 @@ export const TooltipTailWrapper = styled.div`
   min-width: 40px;
   animation-fill-mode: forwards;
   animation-direction: alternate;
-
-  // 애니메이션용 margin-top
-  --move-start-positionTop: -30;
-  --move-end-positionTop: -20;
-
-  @keyframes SHOW_TOOLTIP {
-    from {
-      opacity: 0;
-      margin-top: var(--move-start-positionTop);
-    }
-    to {
-      opacity: 1;
-      margin-top: var(--move-end-positionTop);
-    }
-  }
-
-  @keyframes CLOSE_TOOLTIP {
-    from {
-      opacity: 1;
-      margin-top: var(--move-end-positionTop);
-    }
-    to {
-      opacity: 0;
-      margin-top: var(--move-start-positionTop);
-    }
-  }
+  z-index: 1;
+  opacity: 0;
 
   ${(props: StyleTypes) => {
     const styles: { [key: string]: string } & CSSProperties = {};
 
+    // 말풍선 실행했을 경우
+    if (props.show) styles.opacity = 1;
+
     // 실행 애니메이션을 사용하는 경우
     if (props.useShowAnimation) {
-      styles.transition = "all 0.3s";
-
       if (props.show) {
         // 실행 애니메이션 스타일 적용
-        styles.animation = "SHOW_TOOLTIP 0.3s";
+        if (props.position === "top" || props.position === "bottom") {
+          // 상, 하 애니메이션 적용
+          styles.transition = "margin-top 0.3s";
+          styles.animation = "SHOW_TOOLTIP_TOP 0.3s";
+        } else {
+          // 좌, 우 애니메이션 적용
+          styles.transition = "margin-left 0.3s";
+          styles.animation = "SHOW_TOOLTIP_LEFT 0.3s";
+        }
+      }
+    }
+
+    // 스타일이 적용되었을 경우
+    if (props.tooltipStyles) {
+      // 배경색 변경
+      if (props.tooltipStyles.backgroundColor)
+        styles.backgroundColor = props.tooltipStyles.backgroundColor;
+
+      // 테두리 변경
+      if (props.tooltipStyles.border) {
+        // 테두리 색상 변경
+        if (props.tooltipStyles.border.color)
+          styles.borderColor = props.tooltipStyles.border.color;
+        // 테두리 두께 변경
+        if (props.tooltipStyles.border.width)
+          styles.borderWidth = props.tooltipStyles.border.width;
       }
     }
 
     return styles;
   }}
+
+  // 애니메이션용 margin-top
+  --move-start-position: -25;
+  --move-end-position: -20;
+
+  @keyframes SHOW_TOOLTIP_TOP {
+    from {
+      opacity: 0;
+      margin-top: var(--move-start-position);
+    }
+    to {
+      opacity: 1;
+      margin-top: var(--move-end-position);
+    }
+  }
+
+  @keyframes SHOW_TOOLTIP_LEFT {
+    from {
+      opacity: 0;
+      margin-left: var(--move-start-position);
+    }
+    to {
+      opacity: 1;
+      margin-left: var(--move-end-position);
+    }
+  }
+
+  @keyframes CLOSE_TOOLTIP_TOP {
+    from {
+      opacity: 1;
+      margin-top: var(--move-end-position);
+    }
+    to {
+      opacity: 0;
+      margin-top: var(--move-start-position);
+    }
+  }
+
+  @keyframes CLOSE_TOOLTIP_LEFT {
+    from {
+      opacity: 1;
+      margin-left: var(--move-end-position);
+    }
+    to {
+      opacity: 0;
+      margin-left: var(--move-start-position);
+    }
+  }
+
+  @media ${breakPoints.mobileLarge} {
+    display: none;
+
+    ${(props) =>
+      props.showMobile && {
+        display: "flex",
+      }}
+  }
 `;
 
 export const TooltipTailContents = styled.div`
@@ -92,6 +156,125 @@ export const TooltipTailContents = styled.div`
   font-size: 12px;
 
   ::after {
+    border-color: white transparent;
+    border-style: solid;
+    border-width: 0 6px 8px 6.5px;
+    content: "";
+    display: block;
+    position: absolute;
+    /* top: -7px; */
+    width: 0;
+    z-index: 1;
+    bottom: -6.5px;
+    transform: rotate(180deg);
+
+    // 테두리 스타일 변경
+    ${(props: StyleTypes) => {
+      const styles: { [key: string]: string } & CSSProperties = {};
+
+      if (props.tooltipStyles) {
+        // 말풍선 배경색 변경
+        if (props.tooltipStyles.backgroundColor)
+          styles.borderColor = `${props.tooltipStyles.backgroundColor} transparent`;
+      }
+
+      if (props.position === "bottom") {
+        // 배치가 아래인 경우
+        styles.bottom = "auto";
+        styles.top = "-6.5px";
+        styles.transform = "rotate(0deg)";
+      } else if (props.position === "left" || props.position === "right") {
+        // 배치가 좌, 우인 경우
+        styles.bottom = "50%";
+        styles.right = "-9px";
+        styles.transform = "rotate(90deg)";
+
+        // 오른쪽 배치 처리
+        if (props.position === "right") {
+          styles.left = "-9px";
+          styles.transform = "rotate(270deg)";
+        }
+      }
+
+      return styles;
+    }}
+  }
+
+  ::before {
+    border-color: black transparent;
+    border-style: solid;
+    border-width: 0 6px 8px 6.5px;
+    content: "";
+    display: block;
+    position: absolute;
+    /* top: -8px; */
+    width: 0;
+    z-index: 0;
+    bottom: -8px;
+    transform: rotate(180deg);
+
+    ${(props: StyleTypes) => {
+      const styles: { [key: string]: string } & CSSProperties = {};
+
+      if (props.position === "bottom") {
+        // 배치가 아래일 경우
+        styles.bottom = "auto";
+        styles.top = "-8px";
+        styles.transform = "rotate(0deg)";
+      } else if (props.position === "left" || props.position === "right") {
+        // 배치가 왼쪽인 경우
+        styles.bottom = "50%";
+        styles.right = "-10px";
+        styles.transform = "rotate(90deg)";
+
+        if (props.position === "right") {
+          styles.left = "-10px";
+          styles.transform = "rotate(270deg)";
+        }
+      }
+
+      if (props.tooltipStyles) {
+        // 테두리 스타일 변경
+        if (props.tooltipStyles.border) {
+          // 테두리 색상 변경
+          if (props.tooltipStyles.border.color)
+            styles.borderColor = `${props.tooltipStyles.border.color} transparent`;
+
+          // 테두리 두께 변경
+          if (props.tooltipStyles.border.width) {
+            const width = Number(
+              props.tooltipStyles.border.width.split("px")[0]
+            );
+            // 0이하라면 테두리 표시 안함
+            if (width <= 0) styles.display = "none";
+            // 설정된 테두리만큼 위치값 변경
+            styles.bottom = `${-8 + -width}px`;
+
+            if (props.position === "bottom") {
+              // 배치가 아래인 경우
+              styles.bottom = "auto";
+              styles.top = `${-8 + -width}px`;
+            } else if (
+              props.position === "left" ||
+              props.position === "right"
+            ) {
+              // 배치가 좌, 우인 경우
+              styles.bottom = "50%";
+
+              if (props.position === "left")
+                styles.right = `${-11 + (-width + 1)}px`;
+              if (props.position === "right")
+                styles.left = `${-11 + (-width + 1)}px`;
+            }
+          }
+        }
+      }
+
+      return styles;
+    }}
+  }
+
+  /* ::after {
     position: absolute;
     content: "";
     width: 12px;
@@ -103,5 +286,5 @@ export const TooltipTailContents = styled.div`
     position: absolute;
     z-index: 2;
     bottom: -6.5px;
-  }
+  } */
 `;

--- a/src/components/modules/tooltip/component/tooltip.types.ts
+++ b/src/components/modules/tooltip/component/tooltip.types.ts
@@ -6,23 +6,38 @@ import {
   CommonsSelectorTypes,
 } from "../../../../commons/types/commons.types";
 
+// 말풍선 스타일 타입
+export interface TooltipStylesTypes {
+  backgroundColor?: string; // 말풍선 배경 색상
+  border?: {
+    // 테두리 정보
+    color?: string; // 테두리 색상
+    width?: string; // 테두리 두께
+  };
+}
+
+// 말풍선 배치 위치 타입
+export type TooltipPositionType = "top" | "bottom" | "left" | "right";
+
 export type TooltipPropsType = CommonsChildrenTypes &
   CommonsSelectorTypes & {
     // 말풍선 내용
     tooltipText: string | React.ReactNode;
     // 말풍선 실행 애니메이션 사용 여부, true 전달하면 적용됨 (default : false)
     useShowAnimation?: boolean;
-    // 말풍선 위치
-    position?: {
-      top?: string; // 위
-      // left?: string; // 왼쪽
-    };
     // 비활성화 여부, true를 전달하면 말풍선을 사용하지 않는다. (default : false)
     isDisable?: boolean;
+    // 말풍선 스타일 (색상, 테두리 색상, 두께 등등)
+    tooltipStyles?: TooltipStylesTypes;
+    // 말풍선 위치 (default : top)
+    position?: TooltipPositionType;
+    // 모바일 환경에서도 동일하게 노출시킬 건지에 대한 여부 (default : false)
+    showMobile?: boolean;
   };
 
 export interface TooltipUIPropsType {
-  show: boolean; // 말풍선 보이기 여부
+  show: boolean; // 말풍선 실행 여부
+  render: boolean; // 말풍선 최종 렌더
   toggleTail: (bool: boolean) => () => void;
   tailRef: MutableRefObject<HTMLDivElement>;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -16,18 +12,12 @@
     //////// 변경 내용 ////////
     "noEmit": false,
     "module": "CommonJS",
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "declaration": true,
     "outDir": "./dist",
     ////////////////////////
     "incremental": true
   },
-  "include": [
-    "next-env.d.ts",
-    "src/**/*.tsx",
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "src/**/*.tsx", "src/**/*.ts"],
+  "exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -12,12 +16,18 @@
     //////// 변경 내용 ////////
     "noEmit": false,
     "module": "CommonJS",
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "declaration": true,
     "outDir": "./dist",
     ////////////////////////
     "incremental": true
   },
-  "include": ["next-env.d.ts", "src/**/*.tsx", "src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "src/**/*.tsx",
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8810,10 +8810,10 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
-mcm-js-commons@^0.0.43:
-  version "0.0.43"
-  resolved "https://registry.yarnpkg.com/mcm-js-commons/-/mcm-js-commons-0.0.43.tgz#9a12f879feb953d758d0ce84c08bc4c1890d76b7"
-  integrity sha512-heCfJ/ChF+vKf6sclBGDQ7iRFHaYrd8s0UjFt6nebzO8mnsPCRmgFel50a5xhCP9cfNsPovl3ryKV1xDUNd70w==
+mcm-js-commons@^0.0.64:
+  version "0.0.64"
+  resolved "https://registry.yarnpkg.com/mcm-js-commons/-/mcm-js-commons-0.0.64.tgz#2e7b39db057a9c9f924b009d8be3b0d5a0d1057d"
+  integrity sha512-fqK2kfrX1gODxbplblKxxLrVKY6qFVaA+tM0t+C1kV9VCy4xxLThgxV9MFhOkr7b7jolMjo0HqE1j3GQGoVCmA==
   dependencies:
     "@emotion/react" "^11.10.6"
     "@emotion/styled" "^11.10.6"


### PR DESCRIPTION
position : 말풍선의 위치를 조정할 수 있음, "top", "bottom", "left", "right" 문자열을 넘겨 원하는 말풍선의 위치를 배치할 수 있음
   - top(위), bottom(아래), left(왼쪽), right(오른쪽) 위치로 조정이 되며 기준은 말풍선의 위치를 기준으로 함
tooltipStyles : 말풍선의 스타일 (말풍선 배경, 테두리 색상, 테두리 굵기)를 조정할 수 있음
   - backgroundColor를 통해 말풍선 및 말꼬리의 색상을 변경할 수 있음
   - border 객체에 color와 width 값을 전달할 수 있는데, color는 테두리의 색상, width는 테투리의 굵기를 설정할 수 있음
showMobile : 기본적으로 모바일 환경에서는 말풍선을 실행시키지 않는 것이 디폴트인데, 모바일 환경에서도 말풍선을 동일하게 사용하고 싶을 경우에는 해당 props 값을 전달함

이 외에도 말풍선이 실행될 때의 위치를 말풍선 안의 내용의 크기에 따라 동적으로 조정하여 출력하도록 변경함