### PR TITLE
2023-06-28 :: 모달 styles 적용 방식 변경 및 툴팁 position props 적용 방식 변경

### DIFF
--- a/pages/test/modal/index.tsx
+++ b/pages/test/modal/index.tsx
@@ -84,36 +84,42 @@ export default function ModalExamplePage() {
               id: "aaa",
               name: "test",
               offAutoClose: true,
-              children: (
-                <>111</>
-                // <button
-                //   onClick={() =>
-                //     Modal.open({
-                //       showBGAnimation: true,
-                //       showModalOpenAnimation: true,
-                //       modalSize: { width: "250px", height: "250px" },
-
-                //       children: (
-                //         <button
-                //           onClick={() =>
-                //             Modal.open({
-                //               showBGAnimation: true,
-                //               showModalOpenAnimation: true,
-                //               modalSize: { width: "100px", height: "100px" },
-                //               onCloseModal: () => Modal.close(),
-                //             })
-                //           }
-                //         >
-                //           최하위 모달 오픈
-                //         </button>
-                //       ),
-                //       // onCloseModal: () => Modal.close({ id: "aaas" }),
-                //     })
-                //   }
-                // >
-                //   하위 모달 오픈
-                // </button>
-              ),
+              children: <>111</>,
+              modalSize: {
+                // width: "400px",
+              },
+              modalStyles: {
+                wrapper: {
+                  color: "red",
+                },
+                items: {
+                  width: "200px",
+                },
+                closeButton: {
+                  backgroundColor: "red",
+                  width: "200px",
+                },
+                contents: {
+                  backgroundColor: "skyblue",
+                  width: "50%",
+                },
+              },
+              mobileModalStyles: {
+                wrapper: {
+                  color: "blue",
+                },
+                items: {
+                  width: "300px",
+                },
+                closeButton: {
+                  backgroundColor: "blue",
+                  width: "100px",
+                },
+                contents: {
+                  backgroundColor: "gray",
+                  width: "70%",
+                },
+              },
             })
           }
           type="button"
@@ -235,6 +241,12 @@ export default function ModalExamplePage() {
         </button>
         <input ref={inputRef as any} />
       </p>
+      <button
+        style={{ position: "fixed", top: 0, zIndex: 99999, color: "white" }}
+        onClick={() => setOutOpen(false)}
+      >
+        모달 닫기
+      </button>
     </div>
   );
 }

--- a/pages/test/tooltip/index.tsx
+++ b/pages/test/tooltip/index.tsx
@@ -24,16 +24,16 @@ export default function Test() {
           <_Tooltip
             tooltipText={
               <div>
-                <div>1</div>
-                <div>1</div>
-                <div>1</div>
-                <div>1</div>
-                <div>1</div>
-                <div>1</div>
-                <div>1</div>
-                <div>1</div>
-                <div>1</div>
-                <div>1</div>
+                <div>ㅋ</div>
+                <div>ㅋ</div>
+                <div>ㅋ</div>
+                <div>ㅋ</div>
+                <div>ㅋ</div>
+                <div>ㅋ</div>
+                <div>ㅋ</div>
+                <div>ㅋ</div>
+                <div>ㅋ</div>
+                <div>ㅋ</div>
               </div>
             }
             useShowAnimation

--- a/src/components/modules/modal/component/modal.presenter.tsx
+++ b/src/components/modules/modal/component/modal.presenter.tsx
@@ -28,6 +28,7 @@ const ModalUIPage = (props: {
     _contentsRef,
     modalSize,
     modalStyles,
+    mobileModalStyles,
     mobileModalSize,
     children,
     showModalOpenAnimation,
@@ -66,7 +67,8 @@ const ModalUIPage = (props: {
             data-name={name}
             onMouseDown={handleClickEvent}
             ref={_wrapperRef}
-            style={modalStyles?.wrapper || {}}
+            modalStyle={modalStyles?.wrapper || {}}
+            mobileModalStyles={mobileModalStyles?.wrapper || {}}
           >
             <Items
               className={modalClassList.items}
@@ -75,12 +77,14 @@ const ModalUIPage = (props: {
               showModalOpenAnimation={showModalOpenAnimation}
               isOpen={show}
               ref={_itemRef}
-              style={modalStyles?.items || {}}
+              modalStyle={modalStyles?.items || {}}
+              mobileModalStyles={mobileModalStyles?.items || {}}
             >
               <CloseButtonWrapper
                 className={modalClassList.closeButtonWrapper}
                 isOpen={show}
-                style={buttonWrapperStyles}
+                modalStyle={buttonWrapperStyles}
+                mobileModalStyles={mobileModalStyles?.closeButton || {}}
                 closeMent={closeMent}
               >
                 <_Button
@@ -108,7 +112,8 @@ const ModalUIPage = (props: {
               <ContentsWrapper
                 className={modalClassList.contents}
                 ref={_contentsRef}
-                style={modalStyles?.contents || {}}
+                modalStyle={modalStyles?.contents || {}}
+                mobileModalStyles={mobileModalStyles?.contents || {}}
               >
                 {show ? children : undefined}
               </ContentsWrapper>

--- a/src/components/modules/modal/component/modal.styles.ts
+++ b/src/components/modules/modal/component/modal.styles.ts
@@ -12,6 +12,8 @@ interface StyleTypes {
   hideCloseButton?: boolean;
   closeMent?: string;
   modalCount?: number;
+  modalStyle?: CSSProperties;
+  mobileModalStyles?: CSSProperties;
 }
 
 export const ModalWrapper = styled.div`
@@ -52,6 +54,24 @@ export const Wrapper = styled.div`
   justify-content: center;
   z-index: -1;
   opacity: 0;
+
+  // (웹) modal wrapper style 적용하기
+  ${(props: StyleTypes) => {
+    let styles = {};
+    if (props.modalStyle) styles = props.modalStyle;
+
+    return styles;
+  }}
+
+  @media ${breakPoints.mobileLarge} {
+    // (모바일) modal wrapper style 적용하기
+    ${(props: StyleTypes) => {
+      let styles = {};
+      if (props.mobileModalStyles) styles = props.mobileModalStyles;
+
+      return styles;
+    }}
+  }
 `;
 
 export const Items = styled.div`
@@ -59,23 +79,35 @@ export const Items = styled.div`
   background-color: white;
   border-radius: 10px;
   opacity: 0;
+  width: 500px;
+  height: 500px;
 
+  // (웹) modal items style 적용하기
   ${(props: StyleTypes) => {
-    return {
-      width: props.modalSize?.width ? props.modalSize.width : "500px",
-      height: props.modalSize?.height ? props.modalSize.height : "500px",
-    };
+    let styles = {};
+
+    if (props.modalStyle) styles = props.modalStyle;
+    // modal Size가 있다면 modalStyle의 스타일보다 더 우선 순위를 가진다.
+    if (props.modalSize) styles = { ...styles, ...props.modalSize };
+
+    return styles;
   }}
 
   @media ${breakPoints.mobileLarge} {
-    width: 80% !important;
-    height: 70% !important;
+    width: 80%;
+    height: 70%;
 
-    ${(props) =>
-      props.mobileModalSize && {
-        width: `${props.mobileModalSize.width} !important`,
-        height: `${props.mobileModalSize.height} !important`,
-      }}
+    // (모바일) modal items style 적용하기
+    ${(props: StyleTypes) => {
+      let styles = {};
+
+      if (props.mobileModalStyles) styles = props.mobileModalStyles;
+      // modal Size가 있다면 mobileModalStyle의 스타일보다 더 우선 순위를 가진다.
+      if (props.mobileModalSize)
+        styles = { ...styles, ...props.mobileModalSize };
+
+      return styles;
+    }}
   }
 `;
 
@@ -90,15 +122,24 @@ export const CloseButtonWrapper = styled.div`
   border: unset;
 
   ${(props: StyleTypes) => {
-    const styles: { [key: string]: string | number } & CSSProperties = {};
+    let styles: { [key: string]: string | number } & CSSProperties = {};
 
     // 닫기 버튼 보이기
-    if (props.isOpen) styles.opacity = 1;
-    // 애니메이션 적용하기
-    if (props.isAnimation) styles.transition = "all .3s ease-out";
-    // 버튼 숨기기
-    if (props.hideCloseButton) styles.display = "none";
+    if (props.isOpen) {
+      styles.opacity = 1;
 
+      if (props.hideCloseButton) {
+        // 버튼 숨기기
+        styles.display = "none";
+      } else {
+        // 애니메이션 적용하기
+        if (props.isAnimation) styles.transition = "all .3s ease-out";
+
+        if (props.modalStyle)
+          // (웹) modal closeButton style 적용하기
+          styles = { ...styles, ...props.modalStyle };
+      }
+    }
     return styles;
   }}
 
@@ -125,6 +166,16 @@ export const CloseButtonWrapper = styled.div`
     -ms-user-select: none;
     user-select: none;
   }
+
+  @media ${breakPoints.mobileLarge} {
+    ${(props: StyleTypes) => {
+      // (모바일) modal closeButton style 적용하기
+      let styles = {};
+
+      if (props.mobileModalStyles) styles = props.mobileModalStyles;
+      return styles;
+    }}
+  }
 `;
 
 export const ContentsWrapper = styled.div`
@@ -136,4 +187,22 @@ export const ContentsWrapper = styled.div`
   transition: unset;
   padding: 1rem;
   opacity: 0;
+
+  // (웹) modal contents style 적용하기
+  ${(props: StyleTypes) => {
+    let styles = {};
+
+    if (props.modalStyle) styles = props.modalStyle;
+    return styles;
+  }}
+
+  @media ${breakPoints.mobileLarge} {
+    // (모바일) modal contents style 적용하기
+    ${(props) => {
+      let styles = {};
+
+      if (props.mobileModalStyles) styles = props.mobileModalStyles;
+      return styles;
+    }}
+  }
 `;

--- a/src/components/modules/modal/component/modal.types.ts
+++ b/src/components/modules/modal/component/modal.types.ts
@@ -21,6 +21,14 @@ export type ModalPropsType = CommonsSelectorTypes &
       closeButton?: CSSProperties;
       contents?: CSSProperties;
     };
+    // 모달에 적용되는 스타일, 각각의 태그 별로 설정이 가능하다. (모바일 적용)
+    mobileModalStyles?: {
+      wrapper?: CSSProperties;
+      items?: CSSProperties;
+      closeButton?: CSSProperties;
+      contents?: CSSProperties;
+    };
+
     // 모달 사이즈 (width, height) 지정
     mobileModalSize?: {
       width?: string;

--- a/src/components/modules/tooltip/component/tooltip.container.tsx
+++ b/src/components/modules/tooltip/component/tooltip.container.tsx
@@ -5,6 +5,8 @@ import { MutableRefObject, useEffect, useRef, useState } from "react";
 
 import { TooltipPropsType } from "./tooltip.types";
 
+// position의 종류가 아래의 4가지에 일치하는지 검증
+const filterPosition = ["top", "bottom", "left", "right"];
 // 추가 설명을 위한 말풍선 모듈
 export default function _Tooltip(props: TooltipPropsType) {
   // 중복 실행 방지 변수
@@ -14,6 +16,11 @@ export default function _Tooltip(props: TooltipPropsType) {
   const tailRef = useRef() as MutableRefObject<HTMLDivElement>;
   const { children, tooltipText, useShowAnimation, isDisable, position } =
     props;
+
+  // position이 4가지의 종류에 일치하지 않는다면 기본값 top 부여
+  let _position = filterPosition.some((el) => el === position)
+    ? position
+    : "top";
 
   // 말풍선 실행 여부
   const [show, setShow] = useState(false);
@@ -37,20 +44,20 @@ export default function _Tooltip(props: TooltipPropsType) {
         let movePosition = height;
         let bonus = -5;
 
-        if (position === "bottom") {
+        if (_position === "bottom") {
           // 배치가 아래를 향할 경우
           height = 20;
           bonus = 5;
 
           movePosition = height;
-        } else if (position === "left") {
+        } else if (_position === "left") {
           // 배치가 왼쪽을 향할 경우
           height = height / 2;
           width = width + -25;
 
           movePosition = width;
           tailRef.current.style.marginLeft = `${width + bonus}px`;
-        } else if (position === "right") {
+        } else if (_position === "right") {
           // 배치가 오른쪽을 향할 경우
           height = height / 2;
           width = Math.abs(width) + 25;
@@ -58,8 +65,6 @@ export default function _Tooltip(props: TooltipPropsType) {
           movePosition = width;
           bonus = 5;
           tailRef.current.style.marginLeft = `${width + bonus}px`;
-
-          console.log(movePosition, bonus);
         }
 
         if (useShowAnimation) {
@@ -75,9 +80,9 @@ export default function _Tooltip(props: TooltipPropsType) {
         }
 
         // 말풍선의 최종 위치
-        if (!position || position === "top" || position === "bottom")
+        if (!_position || _position === "top" || _position === "bottom")
           tailRef.current.style.marginTop = `${height + bonus}px`;
-        else if (position === "left" || position === "right") {
+        else if (_position === "left" || _position === "right") {
           tailRef.current.style.marginTop = `${height + 13}px`;
         }
 
@@ -101,7 +106,7 @@ export default function _Tooltip(props: TooltipPropsType) {
         timer = 250; // 변환 시간 지연
 
         if (tailRef && tailRef.current) {
-          if (!position || position === "top" || position === "bottom")
+          if (!_position || _position === "top" || _position === "bottom")
             tailRef.current.style.animation = "CLOSE_TOOLTIP_TOP 0.3s";
           else tailRef.current.style.animation = "CLOSE_TOOLTIP_LEFT 0.3s";
         }
@@ -125,6 +130,7 @@ export default function _Tooltip(props: TooltipPropsType) {
         toggleTail={toggleTail}
         tailRef={tailRef}
         render={render}
+        position={_position}
       />
     </_Error>
   );


### PR DESCRIPTION
1. 기존에 modalSize 또는 modalStyles의 items 객체를 통해 모달의 사이즈를 조절할 수 있었는데, 두개의 props를 함께 전달했을 경우 modalStyles가 우선 적용되는 방식이 취지에 맞지 않는다 판단하여 modalSize가 width와 height에서는 styles 보다 더 우선적인 순위를 가지도록 변경
2. modalStyles로 웹 버전의 모달의 스타일을 변경할 수 있는데 모바일 버전의 스타일이 부재하다 판단하여, mobileModalStyles를 추가적으로 전달하여 767px 이하의 사이즈에서는 모바일 버전의 스타일을 추가적으로 전달할 수 있도록 변경
3. 이 외에도 wrapper, items, closeButton, contents에도 동일하게 웹 버전과 모바일 버전으로 새로 설정 완료함
4. Tooltip 모듈에서는 position props에 "top", "botton", "left", "right"가 아닌 다른 데이터를 전달했을 경우 모듈이 해당 position을 제대로 인식하지 못해 버그가 발생하는 상황이 발생함, 따라서 위의 4가지 데이터와 다를 경우에는 무조건 "top"의 기본값을 참조하도록 변경
   ex ) position에 "left2" 오타가 발생할 경우, 모듈에서는 position을 "top"으로 무조건 인식함