### PR TITLE
2023-07-04 :: Modal timer Props 추가 및 화면 전환시 모달 자동 종료 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcm-js",
-  "version": "0.0.42",
+  "version": "0.0.44",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcm-js",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcm-js",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/pages/test/modal/index.tsx
+++ b/pages/test/modal/index.tsx
@@ -1,7 +1,7 @@
-import React from "react";
 import { Modal } from "../../../src";
-// import Modal from "../../../src/components/modules/modal/modal.container";
-import { useState, useRef } from "react";
+import React, { useState, useRef } from "react";
+import { useRouter } from "next/router";
+import Link from "next/link";
 
 import _Modal from "../../../src/components/modules/modal";
 import { _Input } from "mcm-js-commons";
@@ -14,6 +14,7 @@ export default function ModalExamplePage() {
   const [lastOpen, setLastOpen] = useState(false);
 
   const [outerOpen2, setOuterOpen2] = useState(false);
+  const router = useRouter();
 
   // 모달을 실행하는 함수입니다.
   const openOuterModal = () => {
@@ -34,227 +35,58 @@ export default function ModalExamplePage() {
 
   return (
     <div id="test">
-      <p>
-        <button onClick={openOuterModal} type="button">
-          {" "}
-          모달 실행하기 - Use With State
-        </button>
-        <Modal
-          show={outerOpen}
-          onCloseModal={() => {
-            setOutOpen(false);
-            alert("실행 1");
-          }}
-          id="outer-modal"
-          showBGAnimation
-          showModalOpenAnimation
-          name="test"
-          hideCloseButton
-          timer={10000}
-          offAutoClose
-          onAfterCloseEvent={() => {
-            alert("실행 2");
-          }}
-        >
-          {/* <Modal
-            show={innerOpen}
-            onCloseModal={() => {
-              setInnerOpen(false);
-            }}
-            modalSize={{ width: "250px", height: "250px" }}
-            id="inner-modal"
-            showBGAnimation
-            showModalOpenAnimation
-          >
-            <button onClick={() => setLastOpen(true)}>모달 실행</button>
-            <Modal
-              show={lastOpen}
-              onCloseModal={() => setLastOpen(false)}
-              onAfterCloseEvent={() => {
-                Modal.close({ id: "outer-modal" });
-                setOutOpen(false);
-              }}
-              modalSize={{ width: "100px", height: "100px" }}
-              showBGAnimation
-              showModalOpenAnimation
-              onFixWindow
-            ></Modal>
-          </Modal> */}
-        </Modal>
-      </p>
-      <p>
-        <button
-          onClick={() =>
-            Modal.open({
-              showBGAnimation: true,
-              showModalOpenAnimation: true,
-              id: "aaa",
-              name: "test",
-              offAutoClose: true,
-              children: <>111</>,
-              modalSize: {
-                // width: "400px",
-              },
-              modalStyles: {
-                wrapper: {
-                  color: "red",
-                  backgroundColor: "rgba(30, 0, 50, 0.7)",
-                },
-                items: {
-                  width: "200px",
-                },
-                closeButton: {
-                  backgroundColor: "red",
-                  width: "200px",
-                },
-                contents: {
-                  backgroundColor: "skyblue",
-                  width: "50%",
-                },
-              },
-              mobileModalStyles: {
-                wrapper: {
-                  color: "blue",
-                  backgroundColor: "rgba(100, 0, 50, 0.7)",
-                },
-                items: {
-                  width: "300px",
-                },
-                closeButton: {
-                  backgroundColor: "blue",
-                  width: "100px",
-                },
-                contents: {
-                  backgroundColor: "gray",
-                  width: "70%",
-                },
-              },
-            })
-          }
-          type="button"
-        >
-          모달 실행하기 - In Function
-        </button>
-      </p>
-      <p style={{ height: "2000px" }}>
-        <button onClick={() => setOuterOpen2(true)}>
-          모달 실행하기 - Use With State & Close Modal
-        </button>
-        <Modal
-          show={outerOpen2}
-          onCloseModal={() => setOuterOpen2(false)}
-          showBGAnimation
-          showModalOpenAnimation
-          className="aaab"
-        >
-          <Modal
-            show={true}
-            onCloseModal={() => Modal.close()}
-            showBGAnimation
-            showModalOpenAnimation
-            modalSize={{ width: "400px", height: "400px" }}
-            className="aaa"
-          >
-            <Modal
-              show={true}
-              onCloseModal={() => Modal.close()}
-              showBGAnimation
-              showModalOpenAnimation
-              modalSize={{ width: "300px", height: "300px" }}
-              id="bbbb"
-              className="aaa"
-            >
-              <Modal
-                show={true}
-                onCloseModal={() => Modal.close({ className: "aaa" })}
-                showBGAnimation
-                showModalOpenAnimation
-                modalSize={{ width: "200px", height: "200px" }}
-                className="bbb"
-                id="ccc"
-              ></Modal>
-            </Modal>
-          </Modal>
-        </Modal>
-      </p>
-      <p>
-        <button
-          onClick={() =>
-            Modal.open({
-              show: true,
-              showBGAnimation: true,
-              showModalOpenAnimation: true,
-              id: "a1",
-              children: (
-                <div>
-                  <button
-                    onClick={() =>
-                      Modal.open({
-                        showBGAnimation: true,
-                        showModalOpenAnimation: true,
-                        children: (
-                          <div>
-                            <button
-                              onClick={() =>
-                                Modal.open({
-                                  showBGAnimation: true,
-                                  showModalOpenAnimation: true,
-                                  modalSize: {
-                                    width: "100px",
-                                    height: "100px",
-                                  },
-                                  id: "a3",
-                                  // offAutoClose: true,
-                                  onCloseModal: () => Modal.close({ id: "a1" }),
-                                  onAfterCloseEvent: () => {
-                                    inputRef.current.focus();
-                                  },
-                                  children: (
-                                    <div>
-                                      {/* <button
-                                        onClick={() =>
-                                          Modal.close({ id: "a3" })
-                                        }
-                                      >
-                                        하나만 닫기
-                                      </button>
-                                      <p></p>
-                                      <button
-                                        onClick={() =>
-                                          Modal.close({ id: "a1" })
-                                        }
-                                      >
-                                        모두 닫기
-                                      </button> */}
-                                    </div>
-                                  ),
-                                })
-                              }
-                            >
-                              하위 모달 오픈 2
-                            </button>
-                          </div>
-                        ),
-                        modalSize: { width: "400px", height: "400px" },
-                      })
-                    }
-                  >
-                    하위 모달 오픈 1
-                  </button>
-                </div>
-              ),
-            })
-          }
-        >
-          모달 실행하기 - Multiple & Close Modal
-        </button>
-        <input ref={inputRef as any} />
-      </p>
-      <button
-        style={{ position: "fixed", top: 0, zIndex: 99999, color: "white" }}
-        onClick={() => setOutOpen(false)}
+      <button onClick={() => setOutOpen(true)}>모달 실행</button>
+      <Modal
+        show={outerOpen}
+        onCloseModal={() => setOutOpen(false)}
+        onFixWindow
+        offAutoClose
+        showBGAnimation
+        showModalOpenAnimation
       >
-        모달 닫기
+        <button
+          onClick={() =>
+            Modal.open({
+              children: <div>하위 모달</div>,
+              modalSize: { width: "100px", height: "100px" },
+            })
+          }
+        >
+          하위 모달 열기
+        </button>
+      </Modal>
+      <button
+        onClick={() =>
+          Modal.open({
+            children: (
+              <button
+                onClick={() =>
+                  Modal.open({
+                    children: <div>하위 모달</div>,
+                    modalSize: { width: "100px", height: "100px" },
+                  })
+                }
+              >
+                하위 모달 열기
+              </button>
+            ),
+            onFixWindow: true,
+          })
+        }
+      >
+        모달 열기2
+      </button>
+      <button
+        style={{
+          position: "fixed",
+          top: 0,
+          zIndex: 99999,
+          color: "white",
+          left: "300px",
+        }}
+        onClick={() => router.push("/test/modal2")}
+      >
+        페이지 이동
       </button>
     </div>
   );

--- a/pages/test/modal/index.tsx
+++ b/pages/test/modal/index.tsx
@@ -91,6 +91,7 @@ export default function ModalExamplePage() {
               modalStyles: {
                 wrapper: {
                   color: "red",
+                  backgroundColor: "rgba(30, 0, 50, 0.7)",
                 },
                 items: {
                   width: "200px",
@@ -107,6 +108,7 @@ export default function ModalExamplePage() {
               mobileModalStyles: {
                 wrapper: {
                   color: "blue",
+                  backgroundColor: "rgba(100, 0, 50, 0.7)",
                 },
                 items: {
                   width: "300px",

--- a/pages/test/modal/index.tsx
+++ b/pages/test/modal/index.tsx
@@ -43,13 +43,20 @@ export default function ModalExamplePage() {
           show={outerOpen}
           onCloseModal={() => {
             setOutOpen(false);
+            alert("실행 1");
           }}
           id="outer-modal"
           showBGAnimation
           showModalOpenAnimation
           name="test"
+          hideCloseButton
+          timer={10000}
+          offAutoClose
+          onAfterCloseEvent={() => {
+            alert("실행 2");
+          }}
         >
-          <Modal
+          {/* <Modal
             show={innerOpen}
             onCloseModal={() => {
               setInnerOpen(false);
@@ -72,7 +79,7 @@ export default function ModalExamplePage() {
               showModalOpenAnimation
               onFixWindow
             ></Modal>
-          </Modal>
+          </Modal> */}
         </Modal>
       </p>
       <p>

--- a/pages/test/modal2/index.tsx
+++ b/pages/test/modal2/index.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function ModalPage2() {
+  return <div>2번째 모달 테스트 페이지입니다.</div>;
+}

--- a/src/components/modules/modal/component/modal.container.tsx
+++ b/src/components/modules/modal/component/modal.container.tsx
@@ -23,14 +23,16 @@ export function _RenderModal(props: ModalPropsType) {
     show,
     offAutoClose,
     onCloseModal,
-    openIdx,
-    _wmo,
     showBGAnimation,
     showModalOpenAnimation,
     onAfterCloseEvent,
     onFixWindow,
     timer,
   } = props;
+  let { openIdx, _wmo } = props;
+  // 페이지 전환을 체크하기 위해 현재 모달이 실행되어 있는 페이지 주소 저장
+  let originPathName = "";
+
   const _modalWrapperRef = useRef() as MutableRefObject<HTMLDivElement>;
   const _wrapperRef = useRef() as MutableRefObject<HTMLDivElement>;
   const _itemRef = useRef() as MutableRefObject<HTMLDivElement>;
@@ -106,6 +108,27 @@ export function _RenderModal(props: ModalPropsType) {
         }, (showModalOpenAnimation && 200) || 0);
     }
   }, [show]);
+
+  useEffect(() => {
+    // 현재 페이지 주소 저장
+    if (!originPathName) originPathName = location.pathname;
+
+    return () => {
+      // 페이지 전환을 감지했을 경우
+      if (originPathName !== location.pathname) {
+        ableClose = true;
+        _onCloseModal().then(() => {
+          // 함수로 모달을 오픈했을 경우, 오픈된 모든 모달 제거
+          const list = document.getElementsByClassName("mcm-modal-window-type");
+          if (list.length) {
+            Array.from(list).forEach((node) => {
+              node.remove();
+            });
+          }
+        });
+      }
+    };
+  });
 
   const disableOverflow = () => {
     // 실행되어 있는 여분의 모달이 있는지 검색

--- a/src/components/modules/modal/component/modal.container.tsx
+++ b/src/components/modules/modal/component/modal.container.tsx
@@ -15,6 +15,8 @@ export default function _Modal(
   return <_RenderModal {...props} />;
 }
 
+// 자동 종료 변수
+let autoCloseTimer: number | ReturnType<typeof setTimeout>;
 // 2. 최종 모달 렌더 컴포넌트
 export function _RenderModal(props: ModalPropsType) {
   const {
@@ -27,6 +29,7 @@ export function _RenderModal(props: ModalPropsType) {
     showModalOpenAnimation,
     onAfterCloseEvent,
     onFixWindow,
+    timer,
   } = props;
   const _modalWrapperRef = useRef() as MutableRefObject<HTMLDivElement>;
   const _wrapperRef = useRef() as MutableRefObject<HTMLDivElement>;
@@ -37,6 +40,7 @@ export function _RenderModal(props: ModalPropsType) {
 
   useEffect(() => {
     if (show) {
+      clearTimeout(autoCloseTimer);
       // 스크롤 이동 방지
       if (document.body && onFixWindow) document.body.style.overflow = "hidden";
 
@@ -64,6 +68,13 @@ export function _RenderModal(props: ModalPropsType) {
           }
 
           _itemRef.current?.classList.add(modalFuncClass.itemShow);
+        }
+
+        if (timer >= 1000) {
+          // 최소 1초 이상일 때만 자동종료 실행
+          autoCloseTimer = window.setTimeout(() => {
+            _onCloseModal();
+          }, timer);
         }
       }, 0);
     } else {

--- a/src/components/modules/modal/component/modal.styles.ts
+++ b/src/components/modules/modal/component/modal.styles.ts
@@ -60,6 +60,14 @@ export const Wrapper = styled.div`
     let styles = {};
     if (props.modalStyle) styles = props.modalStyle;
 
+    // 배경색 (background-color)는 최우선 순위로 변경
+    if (props.modalStyle.backgroundColor) {
+      styles = {
+        ...styles,
+        ["backgroundColor"]: `${props.modalStyle.backgroundColor} !important`,
+      };
+    }
+
     return styles;
   }}
 
@@ -68,6 +76,14 @@ export const Wrapper = styled.div`
     ${(props: StyleTypes) => {
       let styles = {};
       if (props.mobileModalStyles) styles = props.mobileModalStyles;
+
+      // 배경색 (background-color)는 최우선 순위로 변경
+      if (props.mobileModalStyles.backgroundColor) {
+        styles = {
+          ...styles,
+          ["backgroundColor"]: `${props.mobileModalStyles.backgroundColor} !important`,
+        };
+      }
 
       return styles;
     }}

--- a/src/components/modules/modal/component/modal.types.ts
+++ b/src/components/modules/modal/component/modal.types.ts
@@ -28,7 +28,6 @@ export type ModalPropsType = CommonsSelectorTypes &
       closeButton?: CSSProperties;
       contents?: CSSProperties;
     };
-
     // 모달 사이즈 (width, height) 지정
     mobileModalSize?: {
       width?: string;
@@ -63,6 +62,8 @@ export type ModalPropsType = CommonsSelectorTypes &
     // 모달이 종료된 다음 시점에 실행될 이벤트
     onFixWindow?: boolean;
     // 모달이 열려있는 상태에서 스크롤 이동을 방지할 건지에 대한 여부
+    timer?: number;
+    // 모달 자동 종료 시간
   };
 
 export interface ModalPropsUITypes {

--- a/src/components/modules/modal/func/index.tsx
+++ b/src/components/modules/modal/func/index.tsx
@@ -174,7 +174,8 @@ export const closeModalFn = async ({
     if (el) return el;
   } else {
     // 그외 state를 이용해서 오픈했을 경우
-    if (wrapperRef.parentElement) return wrapperRef.parentElement;
+    if (wrapperRef && wrapperRef?.parentElement)
+      return wrapperRef.parentElement;
   }
 
   const extraModal = document.getElementsByClassName("mcm-modal-wrapper");


### PR DESCRIPTION
1. 원하는 시간 경과 후에 모달을 자동으로 종료시킬 수 있는 timer props 추가
  - 1초 후에 모달을 종료시키고 싶다면 timer={1000} 또는 timer : 1000 형태로 전달
  - timer가 1000 미만 (1초 미만)일 경우에는 실행되지 않음
2. 모달이 열려있는 상태에서 router.push 또는 Link로 이동하는 태그가 Modal 보다 더 우선순위를 가지고 있을 때 해당 태그로 페이지를 전환할 경우 모달이 종료되지 않고 유지되는 현상이 있었음, 페이지 전환을 체크해서 모달이 열렸을 때의 페이지 주소와 현재(이동된) 페이지의 주소가 동일하지 않을 경우 모달을 자동으로 종료시킬 수 있도록 기능 추가 및 테스트 완료