### PR TITLE
2023-08-07 :: Tooltip 애니메이션 렌더 방식 변경 완료

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcm-js",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/pages/test/modal/index.tsx
+++ b/pages/test/modal/index.tsx
@@ -36,15 +36,32 @@ export default function ModalExamplePage() {
   };
 
   return (
-    <div id="test">
-      <button onClick={() => setOutOpen(true)}>모달 실행</button>
+    <div
+      id="test"
+      style={{ padding: "200px", paddingLeft: "650px", paddingTop: "300px" }}
+    >
+      <button onClick={() => setOutOpen(true)} style={{ fontSize: "24px" }}>
+        모달 실행
+      </button>
       <Modal
         onCloseModal={() => setOutOpen(false)}
         show={outerOpen}
         offAutoClose={offAutoClose}
         onAfterCloseEvent={() => setOffAutoClose(false)}
+        showBGAnimation
+        showModalOpenAnimation
+        closeMent="모달 닫기"
+        modalStyles={{
+          items: {
+            width: "300px",
+            height: "300px",
+          },
+        }}
       >
-        <button onClick={() => setOffAutoClose(true)}> 자동 종료 끄기</button>
+        <button onClick={() => setOffAutoClose(true)}>
+          {" "}
+          Modal Components ...{" "}
+        </button>
       </Modal>
     </div>
   );

--- a/pages/test/modal2/index.tsx
+++ b/pages/test/modal2/index.tsx
@@ -1,5 +1,0 @@
-import React from "react";
-
-export default function ModalPage2() {
-  return <div>2번째 모달 테스트 페이지입니다.</div>;
-}

--- a/pages/test/tooltip/index.tsx
+++ b/pages/test/tooltip/index.tsx
@@ -1,89 +1,29 @@
 import React, { useState } from "react";
 import _Tooltip from "../../../src/components/modules/tooltip/component/tooltip.container";
 
+import { _Title } from "mcm-js-commons";
+
 export default function Test() {
   const [disAble, setDisAble] = useState(false);
   return (
-    <div>
-      <div></div>
-
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          paddingTop: "200px",
-        }}
+    <div style={{ padding: "280px", display: "flex", gap: "0px 100px" }}>
+      <_Tooltip
+        tooltipText={
+          <img style={{ width: "140px" }} src="/images/watermelon.webp" />
+        }
+        useShowAnimation
       >
-        <div
-          style={{
-            display: "flex",
-            gap: "0px 20px",
-          }}
-        >
-          <_Tooltip
-            tooltipText={
-              <div>
-                <div>ㅋ</div>
-                <div>ㅋ</div>
-                <div>ㅋ</div>
-                <div>ㅋ</div>
-                <div>ㅋ</div>
-                <div>ㅋ</div>
-                <div>ㅋ</div>
-                <div>ㅋ</div>
-                <div>ㅋ</div>
-                <div>ㅋ</div>
-              </div>
-            }
-            useShowAnimation
-            tooltipStyles={{
-              backgroundColor: "red",
-              // border: {
-              //   width: "10px",
-              // },
-            }}
-            showMobile
-          >
-            📌
-          </_Tooltip>
-          <_Tooltip
-            tooltipText={
-              <img src="https://us.123rf.com/450wm/mblach/mblach1402/mblach140200030/25799171-%EC%82%AC%EA%B3%BC.jpg" />
-            }
-            // useShowAnimation
-            position="bottom"
-            tooltipStyles={{
-              backgroundColor: "red",
-            }}
-            isDisable
-          >
-            <div>오픈 2</div>
-          </_Tooltip>
-          <_Tooltip tooltipText="open3" useShowAnimation isDisable>
-            <div>오픈 3</div>
-          </_Tooltip>
-        </div>
+        <button style={{ fontSize: "24px" }}>사진 보기</button>
+      </_Tooltip>
 
-        {/* <div>qqqqqqqq</div> */}
-        <div style={{ marginTop: "50px" }}>
-          <_Tooltip
-            tooltipText="안녕하세요? 1231312312312312"
-            // isDisable={disAble}
-            isDisable
-          >
-            <div>
-              {/* 말풍선 오픈하기 */}
-              {/* <span>말풍선 오픈하기</span> */}
-              {/* <h1 style={{ margin: "0px" }}>말풍선 오픈하기</h1> */}
-              {/* <img src="https://us.123rf.com/450wm/mblach/mblach1402/mblach140200030/25799171-%EC%82%AC%EA%B3%BC.jpg" /> */}
-            </div>
-          </_Tooltip>
-        </div>
-      </div>
-      <button onClick={() => setDisAble((prev) => !prev)}>
-        말풍선 {disAble ? "on" : "off"}
-      </button>
+      <_Tooltip
+        tooltipText={
+          <span style={{ fontSize: "20px" }}>수박 (Watermelon)</span>
+        }
+        useShowAnimation
+      >
+        <button style={{ fontSize: "24px" }}>내용 보기</button>
+      </_Tooltip>
     </div>
   );
 }

--- a/pages/test/tooltip/index.tsx
+++ b/pages/test/tooltip/index.tsx
@@ -43,7 +43,6 @@ export default function Test() {
               //   width: "10px",
               // },
             }}
-            position="right"
             showMobile
           >
             📌

--- a/src/components/modules/modal/func/index.tsx
+++ b/src/components/modules/modal/func/index.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { createRoot } from "react-dom/client";
 import OriginModal from "../component/modal.container";
 
@@ -50,7 +51,7 @@ const closeModal = (props?: ModalCloseFuncType) => {
     className: string,
     startNode: Element
   ): HTMLDivElement | null => {
-    let result = null;
+    let result: null | Element = null;
 
     const getNode = (node: Element) => {
       if (node.classList.contains(className)) {

--- a/src/components/modules/tooltip/component/tooltip.container.tsx
+++ b/src/components/modules/tooltip/component/tooltip.container.tsx
@@ -1,3 +1,6 @@
+import React, { createElement } from "react";
+import { createRoot } from "react-dom/client";
+
 import _TooltipUIPage from "./tooltip.presenter";
 
 import { _Error } from "mcm-js-commons";
@@ -12,6 +15,7 @@ export default function _Tooltip(props: TooltipPropsType) {
   // 중복 실행 방지 변수
   let loading = false;
 
+  const wrapperRef = useRef() as MutableRefObject<HTMLDivElement>;
   // 말풍선 ref
   const tailRef = useRef() as MutableRefObject<HTMLDivElement>;
   const { children, tooltipText, useShowAnimation, isDisable, position } =
@@ -37,6 +41,22 @@ export default function _Tooltip(props: TooltipPropsType) {
     if (tailRef && tailRef.current) {
       // 말풍선 오픈시
       if (show) {
+        if (wrapperRef && wrapperRef.current) {
+          const { x, y } = wrapperRef.current.getBoundingClientRect();
+
+          const newDiv = document.createElement("div");
+          newDiv.classList.add("test");
+          newDiv.textContent = "aaa";
+
+          if (newDiv.style) {
+            newDiv.style.left = `${x}px`;
+            newDiv.style.top = `${y - 5}px`;
+          }
+          document.body.appendChild(newDiv);
+
+          createRoot(newDiv).render(<div>2222</div>);
+        }
+
         // 말풍선의 위치값 구하기
         let height = -tailRef.current.offsetHeight;
         let width = -tailRef.current.offsetWidth;
@@ -131,6 +151,7 @@ export default function _Tooltip(props: TooltipPropsType) {
         tailRef={tailRef}
         render={render}
         position={_position}
+        wrapperRef={wrapperRef}
       />
     </_Error>
   );

--- a/src/components/modules/tooltip/component/tooltip.container.tsx
+++ b/src/components/modules/tooltip/component/tooltip.container.tsx
@@ -1,5 +1,4 @@
-import React, { createElement } from "react";
-import { createRoot } from "react-dom/client";
+import React from "react";
 
 import _TooltipUIPage from "./tooltip.presenter";
 
@@ -7,6 +6,7 @@ import { _Error } from "mcm-js-commons";
 import { MutableRefObject, useEffect, useRef, useState } from "react";
 
 import { TooltipPropsType } from "./tooltip.types";
+import { positionList } from "./tooltip.data";
 
 // position의 종류가 아래의 4가지에 일치하는지 검증
 const filterPosition = ["top", "bottom", "left", "right"];
@@ -15,7 +15,6 @@ export default function _Tooltip(props: TooltipPropsType) {
   // 중복 실행 방지 변수
   let loading = false;
 
-  const wrapperRef = useRef() as MutableRefObject<HTMLDivElement>;
   // 말풍선 ref
   const tailRef = useRef() as MutableRefObject<HTMLDivElement>;
   const { children, tooltipText, useShowAnimation, isDisable, position } =
@@ -41,70 +40,26 @@ export default function _Tooltip(props: TooltipPropsType) {
     if (tailRef && tailRef.current) {
       // 말풍선 오픈시
       if (show) {
-        if (wrapperRef && wrapperRef.current) {
-          const { x, y } = wrapperRef.current.getBoundingClientRect();
-
-          const newDiv = document.createElement("div");
-          newDiv.classList.add("test");
-          newDiv.textContent = "aaa";
-
-          if (newDiv.style) {
-            newDiv.style.left = `${x}px`;
-            newDiv.style.top = `${y - 5}px`;
-          }
-          document.body.appendChild(newDiv);
-
-          createRoot(newDiv).render(<div>2222</div>);
-        }
-
-        // 말풍선의 위치값 구하기
-        let height = -tailRef.current.offsetHeight;
-        let width = -tailRef.current.offsetWidth;
-
-        let movePosition = height;
-        let bonus = -5;
-
-        if (_position === "bottom") {
-          // 배치가 아래를 향할 경우
-          height = 20;
-          bonus = 5;
-
-          movePosition = height;
-        } else if (_position === "left") {
-          // 배치가 왼쪽을 향할 경우
-          height = height / 2;
-          width = width + -25;
-
-          movePosition = width;
-          tailRef.current.style.marginLeft = `${width + bonus}px`;
-        } else if (_position === "right") {
-          // 배치가 오른쪽을 향할 경우
-          height = height / 2;
-          width = Math.abs(width) + 25;
-
-          movePosition = width;
-          bonus = 5;
-          tailRef.current.style.marginLeft = `${width + bonus}px`;
-        }
+        const currentPosition = positionList[_position || "top"];
 
         if (useShowAnimation) {
           // 애니메이션 사용중일 경우
+
+          // 시작 기준점
           tailRef.current.style.setProperty(
-            "--move-start-position",
-            `${movePosition}px`
+            `--move-start-${currentPosition.target}`,
+            `${currentPosition.startPoint}%`
           );
+          // 종료 기준점
           tailRef.current.style.setProperty(
-            "--move-end-position",
-            `${movePosition + bonus}px`
+            `--move-end-${currentPosition.target}`,
+            `100%`
           );
         }
 
         // 말풍선의 최종 위치
-        if (!_position || _position === "top" || _position === "bottom")
-          tailRef.current.style.marginTop = `${height + bonus}px`;
-        else if (_position === "left" || _position === "right") {
-          tailRef.current.style.marginTop = `${height + 13}px`;
-        }
+        if (tailRef.current.style)
+          tailRef.current.style[currentPosition.target] = "100%";
 
         setRender(true);
       }
@@ -127,7 +82,9 @@ export default function _Tooltip(props: TooltipPropsType) {
 
         if (tailRef && tailRef.current) {
           if (!_position || _position === "top" || _position === "bottom")
+            // 위 또는 아래 방향일 때
             tailRef.current.style.animation = "CLOSE_TOOLTIP_TOP 0.3s";
+          // 왼쪽 또는 오른쪽 방향일 때
           else tailRef.current.style.animation = "CLOSE_TOOLTIP_LEFT 0.3s";
         }
       }
@@ -151,7 +108,6 @@ export default function _Tooltip(props: TooltipPropsType) {
         tailRef={tailRef}
         render={render}
         position={_position}
-        wrapperRef={wrapperRef}
       />
     </_Error>
   );

--- a/src/components/modules/tooltip/component/tooltip.data.ts
+++ b/src/components/modules/tooltip/component/tooltip.data.ts
@@ -1,0 +1,24 @@
+// 말풍선의 애니메이션 시작점-끝점과 최종 위치값 구하기
+export const positionList: {
+  [key: string]: {
+    target: string; // 애니메이션 작동시, 작동될 스타일 타겟
+    startPoint: number; // 애니메이션 작동시 시작 지점
+  };
+} = {
+  top: {
+    target: "bottom",
+    startPoint: 60,
+  },
+  bottom: {
+    target: "top",
+    startPoint: 60,
+  },
+  left: {
+    target: "right",
+    startPoint: 80,
+  },
+  right: {
+    target: "left",
+    startPoint: 80,
+  },
+};

--- a/src/components/modules/tooltip/component/tooltip.presenter.tsx
+++ b/src/components/modules/tooltip/component/tooltip.presenter.tsx
@@ -26,7 +26,6 @@ export default function _TooltipUIPage(
     tooltipStyles,
     position,
     showMobile,
-    wrapperRef,
   } = props;
 
   return (
@@ -34,9 +33,8 @@ export default function _TooltipUIPage(
       className={getAllComponentsClassName("mcm-tooltip-wrapper", className)}
       id={id}
       onMouseLeave={toggleTail(false)}
-      ref={wrapperRef}
     >
-      <TooltipItems className="mcm-tooltip-items">
+      <TooltipItems className="mcm-tooltip-items" position={position}>
         <TooltipLayout
           className="mcm-tooltip-layout"
           onMouseOver={toggleTail(true)}

--- a/src/components/modules/tooltip/component/tooltip.presenter.tsx
+++ b/src/components/modules/tooltip/component/tooltip.presenter.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import {
   TooltipItems,
   TooltipLayout,
@@ -25,6 +26,7 @@ export default function _TooltipUIPage(
     tooltipStyles,
     position,
     showMobile,
+    wrapperRef,
   } = props;
 
   return (
@@ -32,6 +34,7 @@ export default function _TooltipUIPage(
       className={getAllComponentsClassName("mcm-tooltip-wrapper", className)}
       id={id}
       onMouseLeave={toggleTail(false)}
+      ref={wrapperRef}
     >
       <TooltipItems className="mcm-tooltip-items">
         <TooltipLayout

--- a/src/components/modules/tooltip/component/tooltip.styles.ts
+++ b/src/components/modules/tooltip/component/tooltip.styles.ts
@@ -23,7 +23,25 @@ export const TooltipItems = styled.div`
   flex-direction: column;
   position: relative;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: flex-end;
+
+  ${(props: StyleTypes) => {
+    const styles: CSSProperties & { [key: string]: string } = {};
+
+    if (props.position === "bottom") {
+      // 배치가 아래일 경우
+      styles.justifyContent = "flex-start";
+    } else if (props.position !== "top") {
+      // 배치가 왼쪽, 오른쪽일 경우
+      styles.justifyContent = "center";
+
+      if (props.position === "left") {
+        styles.alignItems = "flex-end";
+      }
+    }
+
+    return styles;
+  }}
 `;
 
 export const TooltipLayout = styled.div`
@@ -44,6 +62,7 @@ export const TooltipTailWrapper = styled.div`
   animation-direction: alternate;
   z-index: 1;
   opacity: 0;
+  transition: all 0.3s;
 
   ${(props: StyleTypes) => {
     const styles: { [key: string]: string } & CSSProperties = {};
@@ -57,11 +76,9 @@ export const TooltipTailWrapper = styled.div`
         // 실행 애니메이션 스타일 적용
         if (props.position === "top" || props.position === "bottom") {
           // 상, 하 애니메이션 적용
-          styles.transition = "margin-top 0.3s";
           styles.animation = "SHOW_TOOLTIP_TOP 0.3s";
         } else {
           // 좌, 우 애니메이션 적용
-          styles.transition = "margin-left 0.3s";
           styles.animation = "SHOW_TOOLTIP_LEFT 0.3s";
         }
       }
@@ -88,50 +105,69 @@ export const TooltipTailWrapper = styled.div`
   }}
 
   // 애니메이션용 margin-top
-  --move-start-position: -25;
-  --move-end-position: -20;
+  --move-start-bottom: unset;
+  --move-end-bottom: unset;
 
+  --move-start-top: unset;
+  --move-end-top: unset;
+
+  --move-start-right: unset;
+  --move-end-right: unset;
+
+  --move-start-left: unset;
+  --move-end-left: unset;
+
+  // 아래에서 위로 오르기
   @keyframes SHOW_TOOLTIP_TOP {
     from {
       opacity: 0;
-      margin-top: var(--move-start-position);
+      bottom: var(--move-start-bottom);
+      top: var(--move-start-top);
     }
     to {
       opacity: 1;
-      margin-top: var(--move-end-position);
+      bottom: var(--move-end-bottom);
+      top: var(--move-end-top);
     }
   }
 
   @keyframes SHOW_TOOLTIP_LEFT {
     from {
       opacity: 0;
-      margin-left: var(--move-start-position);
+      right: var(--move-start-right);
+      left: var(--move-start-left);
     }
     to {
       opacity: 1;
-      margin-left: var(--move-end-position);
+      right: var(--move-end-right);
+      left: var(--move-end-left);
     }
   }
 
+  // 위에서 아래로 내려가기
   @keyframes CLOSE_TOOLTIP_TOP {
     from {
       opacity: 1;
-      margin-top: var(--move-end-position);
+      bottom: var(--move-end-bottom);
+      top: var(--move-end-top);
     }
     to {
       opacity: 0;
-      margin-top: var(--move-start-position);
+      bottom: var(--move-start-bottom);
+      top: var(--move-start-top);
     }
   }
 
   @keyframes CLOSE_TOOLTIP_LEFT {
     from {
       opacity: 1;
-      margin-left: var(--move-end-position);
+      right: var(--move-end-right);
+      left: var(--move-end-left);
     }
     to {
       opacity: 0;
-      margin-left: var(--move-start-position);
+      right: var(--move-start-right);
+      left: var(--move-start-left);
     }
   }
 
@@ -152,6 +188,7 @@ export const TooltipTailContents = styled.div`
   align-items: flex-end;
   padding: 6px;
   width: 100%;
+  min-height: 30px;
   white-space: pre;
   font-size: 12px;
 

--- a/src/components/modules/tooltip/component/tooltip.types.ts
+++ b/src/components/modules/tooltip/component/tooltip.types.ts
@@ -40,6 +40,7 @@ export interface TooltipUIPropsType {
   render: boolean; // 말풍선 최종 렌더
   toggleTail: (bool: boolean) => () => void;
   tailRef: MutableRefObject<HTMLDivElement>;
+  wrapperRef: MutableRefObject<HTMLDivElement>;
 }
 
 export type TooltipType = typeof _Tooltip;

--- a/src/components/modules/tooltip/component/tooltip.types.ts
+++ b/src/components/modules/tooltip/component/tooltip.types.ts
@@ -40,7 +40,6 @@ export interface TooltipUIPropsType {
   render: boolean; // 말풍선 최종 렌더
   toggleTail: (bool: boolean) => () => void;
   tailRef: MutableRefObject<HTMLDivElement>;
-  wrapperRef: MutableRefObject<HTMLDivElement>;
 }
 
 export type TooltipType = typeof _Tooltip;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,3 @@
-// import Modal from "./components/modules/modal/modal.container";
 import Modal from "./components/modules/modal";
 import Tooltip from "./components/modules/tooltip";
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -21,3 +21,7 @@ button {
   cursor: pointer;
   padding: 0px;
 }
+
+.test {
+  position: absolute;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -22,6 +22,11 @@ button {
   padding: 0px;
 }
 
-.test {
+/* Tooltip 관련 */
+
+/* Tooltip 오픈 */
+.open-mcm-tooltip {
   position: absolute;
+  left: 0;
+  top: -20px;
 }


### PR DESCRIPTION
기존에 postion(top, bottom, left, right) 값에 따라 수치를 계산해서 애니메이션을 렌더하는 방식이 tooltip의 children의 크기에 동기화 되지 않거나 렌더되는 시점에서 간혈적으로 어긋나는 이슈를 확인

이유를 확인해보니, 기존 방식 렌더에서는 툴팁에 렌더될 children의 크기를 실시간으로 체크하여 말풍선이 렌더될 구간을 정해놨는데
만약 크기가 큰 이미지거나 네트워크 이슈로 인해 크기가 불안정할 경우 말풍선의 크기가 정해지지 않거나 불안정한 형태로 렌더되는 것을 확인함

해결방안으로 각각의 포지션별로 말풍선의 초기 위치값과 말풍선을 감싸고 있는 부모태그의 정렬방식을 교차하여 렌더하는 방식을 이용해
좀더 안정적인 렌더를 할 수 있도록 변경 완료함