### PR TITLE
2023-08-13 :: Tooltip open, onCloseAfterEvent, onOpenAfterEvent, offHoverEvent props 추가 완료

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcm-js",
-  "version": "0.0.67.7",
+  "version": "0.0.67.8",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/pages/test/tooltip/index.tsx
+++ b/pages/test/tooltip/index.tsx
@@ -17,9 +17,10 @@ export default function Test() {
           }
           useShowAnimation
           position="left"
-          // open={open}
+          open={open}
+          onCloseAfterEvent={() => setOpen(false)}
           // isFix
-          isDisable={open}
+          // isDisable={open}
           hideMobile
         >
           <button style={{ fontSize: "24px" }}>사진 보기</button>

--- a/pages/test/tooltip/index.tsx
+++ b/pages/test/tooltip/index.tsx
@@ -19,6 +19,7 @@ export default function Test() {
           position="left"
           open={open}
           onCloseAfterEvent={() => setOpen(false)}
+          offHoverEvent
           // isFix
           // isDisable={open}
           hideMobile

--- a/src/components/modules/tooltip/component/tooltip.container.tsx
+++ b/src/components/modules/tooltip/component/tooltip.container.tsx
@@ -26,7 +26,8 @@ export default function _Tooltip(props: TooltipPropsType) {
     position,
     open,
     isFix,
-    hideMobile,
+    onCloseAfterEvent,
+    onOpenAfterEvent,
   } = props;
 
   // position이 4가지의 종류에 일치하지 않는다면 기본값 top 부여
@@ -38,6 +39,10 @@ export default function _Tooltip(props: TooltipPropsType) {
   const [tooltipOpen, setTooltipOpen] = useState(open || false);
   // 말풍선 최종 렌더
   const [render, setRender] = useState(false);
+
+  useEffect(() => {
+    toggleTail(open || false)();
+  }, [open]);
 
   // isDisable 설정시, 말풍선 off
   useEffect(() => {
@@ -82,6 +87,7 @@ export default function _Tooltip(props: TooltipPropsType) {
 
   // 마우스 hover시 말풍선 오픈
   const toggleTail = (bool: boolean) => async () => {
+    console.log(bool, tooltipOpen, loading, isDisable);
     if (bool === tooltipOpen || loading || isDisable) return;
     if (!bool && isFix) return; // 고정된 툴팁은 종료되지 않음
 
@@ -108,6 +114,11 @@ export default function _Tooltip(props: TooltipPropsType) {
     window.setTimeout(() => {
       setTooltipOpen(bool);
       loading = false;
+
+      if (!bool && onCloseAfterEvent) onCloseAfterEvent();
+      // 툴팁이 종료될 때 실행될 이벤트가 있을 경우
+      else if (bool && onOpenAfterEvent) onOpenAfterEvent();
+      // 툴팁이 오픈될 때 실행될 이벤트가 있을 경우
     }, timer);
   };
 

--- a/src/components/modules/tooltip/component/tooltip.container.tsx
+++ b/src/components/modules/tooltip/component/tooltip.container.tsx
@@ -28,6 +28,7 @@ export default function _Tooltip(props: TooltipPropsType) {
     isFix,
     onCloseAfterEvent,
     onOpenAfterEvent,
+    offHoverEvent,
   } = props;
 
   // position이 4가지의 종류에 일치하지 않는다면 기본값 top 부여
@@ -40,8 +41,9 @@ export default function _Tooltip(props: TooltipPropsType) {
   // 말풍선 최종 렌더
   const [render, setRender] = useState(false);
 
+  // 수동으로 툴팁을 오픈하거나 종료할 경우
   useEffect(() => {
-    toggleTail(open || false)();
+    if (!isDisable) toggleTail(open || false)();
   }, [open]);
 
   // isDisable 설정시, 말풍선 off

--- a/src/components/modules/tooltip/component/tooltip.presenter.tsx
+++ b/src/components/modules/tooltip/component/tooltip.presenter.tsx
@@ -29,20 +29,21 @@ export default function _TooltipUIPage(
     tooltipMobileStyles,
     position,
     hideMobile,
+    offHoverEvent,
   } = props;
 
   return (
     <TooltipWrapper
       className={getAllComponentsClassName("mcm-tooltip-wrapper", className)}
       id={id}
-      onMouseLeave={toggleTail(false)}
+      onMouseLeave={(!offHoverEvent && toggleTail(false)) || undefined}
       hideMobile={hideMobile}
       ref={wrapperRef}
     >
       <TooltipItems className="mcm-tooltip-items" position={position}>
         <TooltipLayout
           className="mcm-tooltip-layout"
-          onMouseOver={toggleTail(true)}
+          onMouseOver={(!offHoverEvent && toggleTail(true)) || undefined}
         >
           {children}
         </TooltipLayout>

--- a/src/components/modules/tooltip/component/tooltip.types.ts
+++ b/src/components/modules/tooltip/component/tooltip.types.ts
@@ -52,6 +52,8 @@ export type TooltipPropsType = CommonsChildrenTypes &
     onCloseAfterEvent?: () => void;
     // 툴팁이 오픈되면 실행되는 이벤트
     onOpenAfterEvent?: () => void;
+    // 호버 이벤트 무시 여부
+    offHoverEvent?: boolean;
   };
 
 export interface TooltipUIPropsType {

--- a/src/components/modules/tooltip/component/tooltip.types.ts
+++ b/src/components/modules/tooltip/component/tooltip.types.ts
@@ -48,6 +48,10 @@ export type TooltipPropsType = CommonsChildrenTypes &
     isFix?: boolean;
     // 모바일 환경에서도 동일하게 노출시킬 건지에 대한 여부 (default : false)
     hideMobile?: boolean;
+    // 툴팁이 종료되면 실행되는 이벤트
+    onCloseAfterEvent?: () => void;
+    // 툴팁이 오픈되면 실행되는 이벤트
+    onOpenAfterEvent?: () => void;
   };
 
 export interface TooltipUIPropsType {


### PR DESCRIPTION
1. open : 툴팁을 수동으로 실행하거나 종료시킬 수 있는 props, true를 전달하면 수동으로 실행되고 false를 전달하면 수동으로 종료
2. onCloseAfterEvent : 툴팁이 종료될 때 함께 실행할 수 있는 함수
3. onOpenAfterEvent : 툴팁이 실행될 때 함께 실행할 수 있는 함수
4. offHoverEvent : 툴팁의 hover 이벤트를 제거