### PR TITLE
2023-09-04 :: Slider autoPlay와 state 함께 사용시 uid가 변경되는 이슈 수정 완료

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcm-js-dev",
-  "version": "0.0.29.1",
+  "version": "0.0.29.11",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/pages/test/modal/index.tsx
+++ b/pages/test/modal/index.tsx
@@ -16,6 +16,7 @@ export default function ModalExamplePage() {
                 mobileModalSize={{ width: "50%", height: "50%" }}
                 showBGAnimation={true}
                 showModalOpenAnimation={true}
+                autoCloseTimer={2000}
               >
                 <span> 하위 모달을 종료하면 상위 모달도 함께 종료됩니다. </span>
               </Modal>

--- a/pages/test/slider/index.tsx
+++ b/pages/test/slider/index.tsx
@@ -1,75 +1,24 @@
-import React from "react";
-
-import styled from "@emotion/styled";
 import { Slider } from "../../../src";
-import { breakPoints } from "mcm-js-commons/dist/responsive";
+import React, { useState } from "react";
 
-export default function SliderTestPage() {
+export default function Test() {
+  const [test, setTest] = useState(false);
+
   return (
-    <Div>
-      <Slider
-        // useAnimation
-        useAutoPlay={{ delay: 3000, showTimer: true }}
-        // pagination={{ showPageList: true }}
-        useDragMode={{
-          sideMovePercent: 23,
-        }}
-      >
-        <div style={{ backgroundColor: "green" }} className="test">
-          4444
-        </div>
-        <div
-          style={{
-            backgroundImage:
-              'url("https://i.namu.wiki/i/SIHnHey__5syElRWvXqBpod_uf9OtCtB1lgWnxTIn7kxelOGRf-fKrW89m0nmHZ7UtDGkUL8z3rgUqRq_I_exg.webp")',
-            backgroundSize: "cover",
-            width: "100%",
-            height: "100%",
-          }}
-        />
-        <div style={{ backgroundColor: "blue" }} className="test">
-          333
-        </div>
+    <>
+      <button onClick={() => setTest((prev) => !prev)}>
+        {test ? "changed" : "change"}
+      </button>
+      <Slider useAnimation useAutoPlay={{ delay: 3000 }}>
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
       </Slider>
-      {/* <Slider
-        useAnimation
-        useAutoPlay={{ delay: 3000, showTimer: false }}
-        pagination={{ showPageList: true }}
-        // useAutoPlay={{ delay: 4000, showTimer: true }}
-      >
-        <div style={{ backgroundColor: "green" }} className="test">
-          4444
-        </div>
-        <div
-          style={{
-            backgroundImage:
-              'url("https://i.namu.wiki/i/SIHnHey__5syElRWvXqBpod_uf9OtCtB1lgWnxTIn7kxelOGRf-fKrW89m0nmHZ7UtDGkUL8z3rgUqRq_I_exg.webp")',
-            backgroundSize: "cover",
-            width: "100%",
-            height: "100%",
-          }}
-        />
-        <div style={{ backgroundColor: "blue" }} className="test">
-          333
-        </div>
+      {/* <Slider useAnimation useAutoPlay={{ delay: 3000 }}>
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
       </Slider> */}
-    </Div>
+    </>
   );
 }
-
-const Div = styled.div`
-  padding: 100px;
-  /* height: 600px; */
-
-  .test,
-  img {
-    width: 100%;
-    height: 100%;
-    min-height: 300px;
-    object-fit: fill;
-  }
-
-  @media ${breakPoints.mobileLarge} {
-    padding: 20px;
-  }
-`;

--- a/src/commons/types/index.ts
+++ b/src/commons/types/index.ts
@@ -1,4 +1,5 @@
 import { ModalPropsType } from "../../components/modules/modal/component/modal.types";
 import { TooltipPropsType } from "../../components/modules/tooltip/component/tooltip.types";
+import { SliderPropsTypes } from "../../components/modules/slider/components/slider.types";
 
-export type { ModalPropsType, TooltipPropsType };
+export type { ModalPropsType, TooltipPropsType, SliderPropsTypes };

--- a/src/components/modules/modal/component/modal.container.tsx
+++ b/src/components/modules/modal/component/modal.container.tsx
@@ -33,7 +33,7 @@ export function _RenderModal(props: ModalPropsType) {
     showModalOpenAnimation,
     onAfterCloseEvent,
     onFixWindow,
-    timer,
+    autoCloseTimer,
     openIdx,
     _wmo,
   } = props;
@@ -82,11 +82,11 @@ export function _RenderModal(props: ModalPropsType) {
           _itemRef.current?.classList.add(modalFuncClass.itemShow);
         }
 
-        if (timer && timer >= 1000) {
+        if (autoCloseTimer && autoCloseTimer >= 1000) {
           // 최소 1초 이상일 때만 자동종료 실행
           window.setTimeout(() => {
             _onCloseModal(true);
-          }, timer);
+          }, autoCloseTimer);
         }
       }, 0);
     } else {

--- a/src/components/modules/modal/component/modal.types.ts
+++ b/src/components/modules/modal/component/modal.types.ts
@@ -62,7 +62,7 @@ export type ModalPropsType = CommonsSelectorTypes &
     // 모달이 종료된 다음 시점에 실행될 이벤트
     onFixWindow?: boolean;
     // 모달이 열려있는 상태에서 스크롤 이동을 방지할 건지에 대한 여부
-    timer?: number;
+    autoCloseTimer?: number;
     // 모달 자동 종료 시간
   };
 

--- a/src/components/modules/slider/components/list/slider.list.presenter.tsx
+++ b/src/components/modules/slider/components/list/slider.list.presenter.tsx
@@ -13,6 +13,7 @@ export default function SliderListUIPage({
   moveDrag,
   endDrag,
   uid,
+  hasPageList,
 }: SliderListTypes & SliderListUITypes) {
   return (
     <List
@@ -30,6 +31,7 @@ export default function SliderListUIPage({
         useDragMode && moveDrag(e.targetTouches[0].pageX || 0)
       }
       onTouchEnd={(useDragMode && endDrag) || undefined}
+      hasPageList={hasPageList}
     >
       {list.map((el, key) => (
         <Contents key={`${uid}-${key}`} className={sliderClassList.contents}>

--- a/src/components/modules/slider/components/list/slider.list.types.ts
+++ b/src/components/modules/slider/components/list/slider.list.types.ts
@@ -9,6 +9,7 @@ export type SliderListTypes = SliderUIPropsTypes & {
     delay: number; // 자동 넘김 시간 (1000 = 1초), 최소 3초 입력 필요
     showTimer?: boolean; // 타이머 노출 여부
   };
+  hasPageList: boolean;
 };
 
 export interface SliderListUITypes {

--- a/src/components/modules/slider/components/slider.container.tsx
+++ b/src/components/modules/slider/components/slider.container.tsx
@@ -1,4 +1,4 @@
-import { useRef, MutableRefObject, useState, useEffect } from "react";
+import { useRef, MutableRefObject, useState, useEffect, memo } from "react";
 import { SliderPropsTypes, SliderAddProps } from "./slider.types";
 
 import SliderUIPage from "./slider.presenter";
@@ -11,14 +11,13 @@ const timerList: {
   [key: string]: ReturnType<typeof setInterval>;
 } = {};
 
-export default function _RenderSlider(props: SliderPropsTypes) {
+const _RenderSlider = (props: SliderPropsTypes) => {
   const uid = v4();
-
-  return <_Slider {...props} uid={uid} />;
-}
+  return <_Slider {...props} _uid={uid} />;
+};
 
 const _Slider = (props: SliderPropsTypes & SliderAddProps) => {
-  const { children, useAutoPlay, useAnimation, uid } = props;
+  const { children, useAutoPlay, useAnimation, _uid } = props;
 
   const listRef = useRef() as MutableRefObject<HTMLUListElement>;
   const timerRef = useRef() as MutableRefObject<HTMLDivElement>;
@@ -37,6 +36,8 @@ const _Slider = (props: SliderPropsTypes & SliderAddProps) => {
   const [selector, setSelector] = useState(startPage);
   // 일시 중지 변수 (연속 실행 방지)
   const [pause, setPause] = useState(false);
+  // 최초로 받은 uid 고정시키기
+  const [uid] = useState(_uid);
 
   useEffect(() => {
     setPause(false);
@@ -192,3 +193,5 @@ const _Slider = (props: SliderPropsTypes & SliderAddProps) => {
     </_Error>
   );
 };
+
+export default memo(_RenderSlider);

--- a/src/components/modules/slider/components/slider.presenter.tsx
+++ b/src/components/modules/slider/components/slider.presenter.tsx
@@ -28,6 +28,7 @@ export default function SliderUIPage({
   useDragMode,
   uid,
   timerList,
+  hideArrow,
 }: SliderPropsTypes & SliderUIPropsTypes) {
   return (
     (children && children.length && Array.isArray(children) && (
@@ -39,12 +40,14 @@ export default function SliderUIPage({
         id={id}
       >
         <Items className={sliderClassList.items}>
-          <ArrowButton
-            onClickEvent={moveSlider({ type: "prev", selector })}
-            className={sliderClassList.prevArrow}
-          >
-            ◀
-          </ArrowButton>
+          {!hideArrow && (
+            <ArrowButton
+              onClickEvent={moveSlider({ type: "prev", selector })}
+              className={sliderClassList.prevArrow}
+            >
+              ◀
+            </ArrowButton>
+          )}
           <SliderListPage
             useAnimation={useAnimation}
             listRef={listRef}
@@ -56,13 +59,14 @@ export default function SliderUIPage({
             selector={selector}
             moveSlider={moveSlider}
             children={children}
+            hasPageList={pagination?.showPageList || false}
           />
 
           {/* 페이지네이션 기능을 사용할 경우 */}
           {pagination && pagination.showPageList && (
             <Pagination
               className={sliderClassList.pagination}
-              style={{ bottom: useAutoPlay?.showTimer ? "30px" : "10px" }}
+              style={{ bottom: useAutoPlay?.showTimer && "20px" }}
             >
               {Array.from(new Array(children.length), (_, idx) => idx).map(
                 (page) => {
@@ -84,12 +88,14 @@ export default function SliderUIPage({
               )}
             </Pagination>
           )}
-          <ArrowButton
-            onClickEvent={moveSlider({ type: "next", selector })}
-            className={sliderClassList.nextArrow}
-          >
-            ▶
-          </ArrowButton>
+          {!hideArrow && (
+            <ArrowButton
+              onClickEvent={moveSlider({ type: "next", selector })}
+              className={sliderClassList.nextArrow}
+            >
+              ▶
+            </ArrowButton>
+          )}
           {useAutoPlay && useAutoPlay.showTimer && useAutoPlay.delay && (
             <Timer
               ref={timerRef}

--- a/src/components/modules/slider/components/slider.styles.ts
+++ b/src/components/modules/slider/components/slider.styles.ts
@@ -8,6 +8,7 @@ interface StyleTypes {
   delay?: number;
   useAnimation?: boolean;
   hasDragMode?: boolean;
+  hasPageList?: boolean;
 }
 
 export const Wrapper = styled.div`
@@ -41,6 +42,7 @@ export const List = styled.ul`
   padding: 0px;
   z-index: 97;
   transform: translateX(-200%);
+  min-height: 40px;
 
   // 드래그시 추가 이동 위치값
   --margin-left: 0;
@@ -56,6 +58,11 @@ export const List = styled.ul`
     // 슬라이더 기능 사용시
     if (props.hasDragMode) {
       styles.cursor = "grab";
+    }
+
+    // 페이지네이션을 사용할 경우
+    if (props.hasPageList) {
+      styles.minHeight = "80px";
     }
 
     return styles;
@@ -110,6 +117,8 @@ export const Contents = styled.li`
   min-width: 100%;
   width: 100%;
   display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
 export const ArrowButton = styled(_Button)`
@@ -124,8 +133,15 @@ export const ArrowButton = styled(_Button)`
   opacity: 1;
   font-size: 18px;
 
+  /* pointer-events: none; // PC 이미지 다운로드 금지 */
+  /* -webkit-touch-callout: none; // 아이폰 다운로드 금지 */
+  /* -webkit-user-select: none; // 드래그 방지
+  -moz-user-select: none;
+  -ms-use-select: none;
+  user-select: none; */
+
   :hover {
-    background-color: rgba(255, 255, 255, 0.4);
+    background-color: rgba(125, 125, 125, 0.25);
   }
 `;
 
@@ -134,7 +150,7 @@ export const Pagination = styled.div`
   position: absolute;
   left: 50%;
   transform: translate(-50%, -50%);
-  bottom: 10px;
+  bottom: 0px;
   width: auto;
   gap: 0px 8px;
   white-space: pre;

--- a/src/components/modules/slider/components/slider.types.ts
+++ b/src/components/modules/slider/components/slider.types.ts
@@ -21,10 +21,12 @@ export type SliderPropsTypes = CommonsSelectorTypes & {
   useDragMode?: {
     sideMovePercent: number; // 좌우 이동 비율 (최소 10% ~ 90%)
   };
+  // 다음, 이전 버튼 숨기기
+  hideArrow?: boolean;
 };
 
 export interface SliderAddProps {
-  uid: string;
+  _uid: string;
 }
 
 export interface SliderUIPropsTypes {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -16,20 +12,12 @@
     //////// 변경 내용 ////////
     "noEmit": false,
     "module": "CommonJS",
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "declaration": true,
     "outDir": "./dist",
     ////////////////////////
     "incremental": true
   },
-  "include": [
-    "next-env.d.ts",
-    "src/**/*.tsx",
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "**/*.spec.ts",
-    "**/*.test.ts"
-  ]
+  "include": ["next-env.d.ts", "src/**/*.tsx", "src/**/*.ts"],
+  "exclude": ["node_modules", "**/*.spec.ts", "**/*.test.ts"]
 }


### PR DESCRIPTION
1. Slider 모듈에 autoPlay 기능이 적용되어 있는 상태에서 페이지 어디서든 state가 변경되었을 때 uid가 자동으로 변경되고 이때 수동으로 페이지를 전환하면 변경된 uid로 새로운 setInterval 함수가 등록되어 2번의 이벤트가 실행되는 이슈 수정 완료
  - 전달받은 uid props를 uid state로 고정시켜 uid가 변경이 되더라도 최초로 받은 uid만 사용할 수 있도록 변경
2. Modal 모듈의 timer props 이름을 autoCloseTimer로 변경
3. Slider 모듈에 hideArrow props를 전달하면 이전/다음으로 이동하는 버튼을 제거할 수 있음